### PR TITLE
(IAC-647) Improve type generation and make provider idempotent

### DIFF
--- a/Get-DscResourceTypeInformation.ps1
+++ b/Get-DscResourceTypeInformation.ps1
@@ -1,0 +1,133 @@
+Function Get-DscResourceTypeInformation {
+  <#
+    .SYNOPSIS
+      Collate the information about a DSC resource for building a Puppet resource_api type.
+
+    .DESCRIPTION
+      This function leverages the Get-DscResource command and the AST for DSC Resources implemented
+      in PowerShell to return additional information about the DSC Resource for building a Puppet
+      resource_api compliant Type, including retrieving help info, default values, and mandatory status.
+
+    .PARAMETER DscResource
+      The DscResourceInfo object to introspect; can be passed via the pipeline, normally retrieved
+      via calling Get-DscResource.
+
+    .PARAMETER DscResourceName
+      If not passing a full object, specify the name of the DSC Resource to retrieve and introspect.
+
+    .PARAMETER ModuleName
+      If not passing a full object, specify the module name of the the DSC Resource to retrieve and introspect.
+      Can be either a string or a hash containing the keys ModuleName and ModuleVersion.
+
+    .EXAMPLE
+      Get-DscResource -Name PSRepository | Get-DscResourceTypeInformation
+    
+    .EXAMPLE
+      Get-DscResourceTypeInformation -DscResourceName PSRepository
+
+    .NOTES
+    This function currently takes EITHER:
+
+    1. A DscResource Object, as passed by Get-DSCResource
+    2. A combo of name/module to retrieve DSC Resources from
+  #>
+  [CmdletBinding()]
+  Param(
+    [Parameter(ValueFromPipeline)]
+    [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo[]]$DscResource,
+    $DscResourceName,
+    $ModuleName
+  )
+  Begin{}
+  Process {
+    # Retrieve the DSC Resource information from the system unless passed directly
+    If ($null -eq $DscResource) {
+      if ($null -eq $ModuleName) {
+        $DscResource = Get-DscResource -Name $DscResourceName
+      } else {
+        $DscResource = Get-DscResource -Name $DscResourceName -Module $ModuleName
+      }
+    }
+    Write-Verbose "Processing DscResource: $($DscResource.Name)"
+    Write-Verbose "Module Name:            $($DscResource.ModuleName)"
+    Write-Verbose "Module Version:         $($DscResource.Version)"
+    Write-Verbose "Implemented As:         $($DscResource.ImplementedAs)"
+    Write-Verbose "Path:                   $($DscResource.Path)"
+    # We have to copy the info into a custom object because the DscResourceInfo object did not want to
+    # add an array property for inserting additional information. A bit silly but it works so /shrug
+    $ResourceInformation = [PSCustomObject]@{
+      Name               = $DscResource.Name.ToLowerInvariant()
+      FriendlyName       = $DscResource.FriendlyName
+      ProviderName       = $DscResource.provider_name
+      ResourceType       = $DscResource.ResourceType
+      Module             = $DscResource.Module
+      ModuleName         = $DscResource.ModuleName
+      Version            = $DscResource.Version
+      ImplementedAs      = $DscResource.ImplementedAs
+      relative_mof_path  = $DscResource.relative_mof_path
+      Properties         = $DscResource.Properties
+      allowed_properties = $DscResource.allowed_properties
+      ParameterInfo      = New-Object -TypeName System.Collections.ArrayList
+    }
+    # We can only parse PowerShell-implemented DSC resources for now
+    If ($DscResource.ImplementedAs -eq 'PowerShell') {
+      $ParsedAst = [system.management.automation.language.parser]::ParseFile($DscResource.Path, [ref]$null, [ref]$null)
+    }
+    If ($null -ne $ParsedAst) {
+      # We can curreently only retrieve parameter metadata from function and composite DSC resources, not class-based :(
+      # There are probably more elegant AST filters but this worked for now.
+      $GetFunctionAst = $ParsedAst.FindAll({$true}, $true) | Where-Object -FilterScript {$_.Name -eq 'Get-TargetResource'}
+      $SetFunctionAst = $ParsedAst.FindAll({$true}, $true) | Where-Object -FilterScript {$_.Name -eq 'Set-TargetResource'}
+      $FilterForMandatoryParameters = {
+        $MandatoryAttribute = $_.Attributes.NamedArguments | Where-Object -FilterScript {
+          $_.ArgumentName -eq 'Mandatory' -and
+          [string]$_.Argument -eq '$true'
+        }
+        $null -ne $MandatoryAttribute
+      }
+      If ($null -ne $GetFunctionAst) {
+        $MandatoryGetParameters = $GetFunctionAst.body.ParamBlock.Parameters |
+          Where-Object -FilterScript $FilterForMandatoryParameters
+      }
+      If ($null -ne $SetFunctionAst) {
+        $MandatorySetParameters = $SetFunctionAst.body.ParamBlock.Parameters |
+          Where-Object -FilterScript $FilterForMandatoryParameters
+        # We only care about searching for help info on the set as it's the closest analog
+        $HelpInfo = $SetFunctionAst.GetHelpContent().Parameters
+      }
+    }
+    # We iterate over allowed_properties to get those that will work via Invoke-DscResource
+    # Note that this will always return PSDscRunAsCredential (if run on 5x), which doesn't work in 7+
+    ForEach ($Parameter in $DscResource.allowed_properties) {
+      If ($null -ne $HelpInfo) {
+        $ParameterDescription = $HelpInfo[$Parameter.Name.ToUpper()]
+        If ($null -ne $ParameterDescription) { $ParameterDescription = $ParameterDescription.Trim()}
+      } Else { $ParameterDescription = $null }
+      If ($null -ne $SetFunctionAst) {
+        $MandatorySet = ("`$$($Parameter.Name)" -in [string[]]$MandatorySetParameters.Name)
+        $DefaultValue = $SetFunctionAst.body.ParamBlock.Parameters |
+          Where-Object  -FilterScript { $_.Name -match [string]$Parameter.Name } |
+          Select-Object -ExpandProperty DefaultValue
+      } Else { $MandatorySet = $Parameter.Required }
+      If ($null -ne $GetFunctionAst) {
+        $MandatoryGet = ("`$$($Parameter.Name)" -in [string[]]$MandatoryGetParameters.Name)
+      } Else { $MandatoryGet = $Parameter.Required }
+      # We want to return all the useful info from allowed_properties PLUS
+      # the help (if any), the default set value (if any), and whether or not the param is mandatory
+      # for get or set calls (it *may* be manadatory for set but not get) - if we can't parse, default
+      # to using the Required designation from Get-DscResource, which only cares about setting.
+      $ResourceInformation.ParameterInfo.Add([pscustomobject] @{
+        Name              = $Parameter.Name.ToLowerInvariant()
+        DefaultValue      = $DefaultValue
+        Type              = $Parameter.Type
+        Help              = $ParameterDescription
+        mandatory_for_get = $MandatoryGet.ToString().ToLowerInvariant()
+        mandatory_for_set = $MandatorySet.ToString().ToLowerInvariant()
+        mof_type          = $Parameter.ShortType
+        mof_is_embedded   = $Parameter.EmbeddedInstance.ToString().ToLowerInvariant()
+      }) | Out-Null
+    }
+    $ResourceInformation
+  }
+  End {}
+}

--- a/build.ps1
+++ b/build.ps1
@@ -40,8 +40,17 @@ Pop-Location
 ## copy pdk specific files
 Copy-Item -Path (Join-Path -Path $templateDir 'pdk/*') -Destination $moduleDir -Recurse -Force
 $metadatajson = Get-Content -Path (Join-Path $moduleDir "metadata.json") | ConvertFrom-Json
-$metadatajson.dependencies = @( @{ "name" = "puppetlabs/pwshlib"; "version_requirement" = ">= 0.1.0 < 2.0.0" } )
-$metadatajson | ConvertTo-Json | Set-Content -Path (Join-Path $moduleDir "metadata.json") -Encoding UTF8
+$metadatajson.dependencies = @( @{ "name" = "puppetlabs/pwshlib"; "version_requirement" = ">= 0.4.0 < 2.0.0" } )
+[IO.File]::WriteAllLines(
+  (Join-Path $moduleDir "metadata.json"),
+  (ConvertTo-Json -InputObject $metadatajson)
+)
+$FixturesYaml = Get-Content -Path (Join-Path $moduleDir ".fixtures.yml") -Raw | ConvertFrom-Yaml
+$FixturesYaml.fixtures.forge_modules = @{pwshlib = 'puppetlabs/pwshlib'}
+[IO.File]::WriteAllLines(
+  (Join-Path $moduleDir ".fixtures.yml"),
+  ("---`n" + (ConvertTo-Yaml -Data $FixturesYaml))
+)
 
 # copy resource_api base classes
 Get-ChildITem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'templates/resource_api/*') | Copy-Item -Destination $moduleDir -Recurse -Force

--- a/build.ps1
+++ b/build.ps1
@@ -37,13 +37,7 @@ if(-not(Test-Path $downloadedDscResources)){
   ForEach ($ModuleFolder in (Get-ChildItem $downloadedDscResourcesTmp)) {
     Move-Item -Path (Get-ChildItem $ModuleFolder.FullName).FullName -Destination "$downloadedDscResources/$($ModuleFolder.Name)"
   }
-
-# create new pdk module
-if(-not(Test-Path $importDir)){
-  mkdir $importDir
-}
-if(Test-Path $moduleDir){
-  Remove-Item -Path $moduleDir -Force -Recurse
+  Remove-Item $downloadedDscResourcesTmp -Recurse
 }
 
 ## copy pdk specific files

--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,27 @@
+<#
+  .SYNOPSIS
+    Puppetize a PowerShell module with DSC resources
+  .DESCRIPTION
+    This script builds a Puppet Module which wraps and calls PowerShell DSC resources
+    via the Puppet resource_api. This module:
+
+    - Includes a base resource_api provider which relies on ruby-pwsh and knows how to invoke DSC resources
+    - Includes a type for each DSC resource, pulling in the appropriate metadata including help, default value
+      and mandatory status, as well as whether or not it includes an embedded mof.
+    - Allows for the tracking of changes on a property-by-property basis while using DSC and Puppet together
+  .PARAMETER PowerShellModuleName
+    The name of the PowerShell module on the gallery which has DSC resources you want to Puppetize
+  .PARAMETER PowerShellModuleVersion
+    The version of the PowerShell module on the gallery which has DSC resources you want to Puppetize.
+    If left blank, will default to latest available.
+  .PARAMETER PuppetModuleName
+    The name of the Puppet module for the wrapper; if not specified, will default to the downcased name of
+    the module to adhere to Puppet naming conventions.
+  .EXAMPLE
+    .\build.ps1 -PowerShellModuleName PowerShellGet -PowerShellModuleVersion 2.2.3
+  .NOTES
+    For right now, we require the EPS & powershell-yaml PowerShell modules and the PDK
+#>
 [CmdletBinding()]
 param(
   $PuppetModuleName,

--- a/build.ps1
+++ b/build.ps1
@@ -64,15 +64,15 @@ Get-ChildITem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'templates/resourc
 
 Update-TypeData -PrependPath $dscResourcePowerShellTypes
 
-$oldPsModulePath = $env:PSModulePath
-$env:PSModulePath = "$($downloadedDscResources);" + $env:PSModulePath
-$global:resources = Get-DscResource
-
-# ipmo C:\Users\james\src\puppetlabs\eps\EPS\EPS.psd1
-iF(!(Get-Module -Name 'EPS')){
+If (!(Get-Module -Name 'EPS' -ListAvailable)) {
   Install-Module -Name 'EPS'
 }
 Import-Module -Name 'EPS'
+
+$oldPsModulePath  = $env:PSModulePath
+$env:PSModulePath = "$($downloadedDscResources);"
+$global:resources = Get-DscResource -Module $PowerShellModuleName
+
 # EPS requires global variables to keep them in accessible scope
 # Also need to set the variable to null inside the loop
 # Files are written using UTF8, but newlines will need to addressed

--- a/build.ps1
+++ b/build.ps1
@@ -7,6 +7,8 @@ param(
 
 If ($null -eq $PuppetModuleName) { $PuppetModuleName = $PowerShellModuleName.tolower() }
 
+. $PSScriptRoot\Get-DscResourceTypeInformation.ps1
+
 $importDir   = Join-Path $PSScriptRoot 'import'
 $templateDir = Join-Path $PSScriptRoot 'templates'
 $moduleDir   = Join-Path $importDir $PuppetModuleName
@@ -74,7 +76,7 @@ Import-Module -Name 'EPS'
 
 $oldPsModulePath  = $env:PSModulePath
 $env:PSModulePath = "$($downloadedDscResources);"
-$global:resources = Get-DscResource -Module $PowerShellModuleName
+$global:resources = Get-DscResource -Module $PowerShellModuleName | Get-DscResourceTypeInformation
 
 # EPS requires global variables to keep them in accessible scope
 # Also need to set the variable to null inside the loop
@@ -82,7 +84,7 @@ $global:resources = Get-DscResource -Module $PowerShellModuleName
 foreach($resource in $resources){
   $global:resource = $resource
 
-  $dscResourceName = "dsc_$($resource.Name.ToLowerInvariant())"
+  $dscResourceName = "dsc_$($resource.Name)"
   if(-not(Test-Path $puppetTypeDir)){
     mkdir $puppetTypeDir | Out-Null
   }

--- a/build.ps1
+++ b/build.ps1
@@ -88,7 +88,7 @@ foreach($resource in $resources){
   }
   [string]$puppetTypeFileName = [IO.Path]::Combine($puppetTypeDir, "$($dscResourceName).rb")
   $puppetTypeText = Invoke-EpsTemplate -Path $puppetTypeTemplate
-  [IO.File]::WriteAllText($puppetTypeFileName, $puppetTypeText, [Text.Encoding]::UTF8)
+  [IO.File]::WriteAllLines($puppetTypeFileName, $puppetTypeText)
 
   [string]$puppetTypeProviderDir  = Join-Path $puppetProviderDir "$($dscResourceName)"
   [string]$puppetProviderFileName = [IO.Path]::Combine($puppetProviderDir, "$($dscResourceName)", "$($dscResourceName).rb")
@@ -96,7 +96,7 @@ foreach($resource in $resources){
     mkdir $puppetTypeProviderDir | Out-Null
   }
   $puppetProviderText = Invoke-EpsTemplate -Path $puppetProviderTemplate
-  [IO.File]::WriteAllText($puppetProviderFileName, $puppetProviderText, [Text.Encoding]::UTF8)
+  [IO.File]::WriteAllLines($puppetProviderFileName, $puppetProviderText)
 
   $resource = $Null
 }

--- a/templates/dsc_provider.eps
+++ b/templates/dsc_provider.eps
@@ -1,5 +1,5 @@
 require_relative '../dsc_base_provider/dsc_base_provider'
 
 # Implementation for the dsc_type type using the Resource API.
-class Puppet::Provider::Dsc<%= $resource.provider_name -%>::Dsc<%= $resource.provider_name -%> < Puppet::Provider::DscBaseProvider
+class Puppet::Provider::Dsc<%= $Resource.ProviderName -%>::Dsc<%= $Resource.ProviderName -%> < Puppet::Provider::DscBaseProvider
 end

--- a/templates/dsc_type.eps
+++ b/templates/dsc_type.eps
@@ -10,7 +10,7 @@ Puppet::ResourceApi.register_type(
     The DSC <%= $resource.friendlyname %> resource type.
     Automatically generated from version <%= $resource.version %>
   },
-  features: [],
+  features: ['simple_get_filter'],
   attributes: {
     ensure: {
       type:    'Enum[present, absent]',

--- a/templates/dsc_type.eps
+++ b/templates/dsc_type.eps
@@ -1,15 +1,14 @@
 require 'puppet/resource_api'
 
 Puppet::ResourceApi.register_type(
-  name: 'dsc_<%= $resource.name.ToLowerInvariant() %>',
+  name: 'dsc_<%= $resource.name %>',
   dscmeta_resource_friendly_name: '<%= $resource.friendlyname %>',
   dscmeta_resource_name: '<%= $resource.resourcetype %>',
   dscmeta_module_name: '<%= $resource.modulename %>',
   dscmeta_module_version: '<%= $resource.version %>',
   docs: %q{
     The DSC <%= $resource.friendlyname %> resource type.
-    Automatically generated from
-    '<%= $resource.relative_mof_path %>'
+    Automatically generated from version <%= $resource.version %>
   },
   features: [],
   attributes: {
@@ -20,15 +19,20 @@ Puppet::ResourceApi.register_type(
     },
     name: {
       type:      'String',
-      desc:      'The name of the resource you want to manage.',
+      desc:      'Description of the purpose for this resource declaration.',
       behaviour: :namevar,
     },
-<% $resource.allowed_properties | Each { -%>
-    dsc_<%= $_.name.ToLowerInvariant() -%>: {
+<% $resource.ParameterInfo | Each { -%>
+    dsc_<%= $_.name -%>: {
       type: <%= $_.Type %>,
-      desc: '<%= $_.Name %>',
-      mof_type: '<%= $_.ShortType %>',
-      mof_is_embedded: <%= $_.embeddedinstance.tostring().tolowerinvariant() %>,
+      desc: %q{
+        <%= $_.Help %>
+      },
+<%= if($_.mandatory_for_get -eq 'true'){"      behaviour: :namevar,`n"} -%>
+      mandatory_for_get: <%= $_.mandatory_for_get %>,
+      mandatory_for_set: <%= $_.mandatory_for_set %>,
+      mof_type: '<%= $_.mof_type %>',
+      mof_is_embedded: <%= $_.mof_is_embedded %>,
     },
 <% }  -%>
   },

--- a/templates/resource_api/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/templates/resource_api/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -22,13 +22,12 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
     ]
   end
 
-  def create(context, name, should)
-    context.notice("Creating '#{name}' with #{should.inspect}")
+  def invoke_set_method(context, name, should)
+    context.notice("Ivoking Set Method for '#{name}' with #{should.inspect}")
     resource = should_to_resource(should, context, 'set')
     script_content = ps_script_content(resource)
     context.debug("Script:\n #{script_content}")
 
-    require 'pry';binding.pry
     output = ps_manager.execute(script_content)[:stdout]
     context.err('Nothing returned') if output.nil?
 
@@ -40,22 +39,19 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
     data
   end
 
+  def create(context, name, should)
+    context.notice("Creating '#{name}' with #{should.inspect}")
+    invoke_set_method(context, name, should)
+  end
+
   def update(context, name, should)
     context.notice("Updating '#{name}' with #{should.inspect}")
-    # there isn't a direct correlation for update in dsc, it's get|set
-    # possible just implement set in provider, not any of create|update|delete ?
+    invoke_set_method(context, name, should)
   end
 
   def delete(context, name)
     context.notice("Deleting '#{name}'")
-
-    resource = should_to_resource(should, context, 'set')
-    script_content = ps_script_content(resource)
-    # output         = ps_manager.execute(script_content)[:stdout]
-    # data           = JSON.parse(output)
-    # context.err(data['errormessage']) if !data['errormessage'].empty?
-    # # notify_reboot_pending if data['rebootrequired'] == true
-    # data
+    invoke_set_method(context, name, should)
   end
 
   def should_to_resource(should, context, dsc_invoke_method)

--- a/templates/resource_api/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/templates/resource_api/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -61,7 +61,7 @@ class Puppet::Provider::DscBaseProvider < Puppet::ResourceApi::SimpleProvider
   def should_to_resource(should, context, dsc_invoke_method)
     resource = {}
     resource[:parameters] = {}
-    [:name, :dscmeta_resource_friendly_name, :dscmeta_resource_name, :dscmeta_module_name].each do |k|
+    [:name, :dscmeta_resource_friendly_name, :dscmeta_resource_name, :dscmeta_module_name, :dscmeta_module_version].each do |k|
       resource[k] = context.type.definition[k]
     end
     should.each do |k,v|

--- a/templates/resource_api/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_postscript.ps1.erb
+++ b/templates/resource_api/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_postscript.ps1.erb
@@ -16,4 +16,7 @@ switch ($invokeParams.Method) {
     $response.rebootrequired = $result.RebootRequired
     return ($response | ConvertTo-Json -Compress)
   }
+  'Get' {
+    return ($result | ConvertTo-Json -Compress -Depth 10)
+  }
 }

--- a/templates/resource_api/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_postscript.ps1.erb
+++ b/templates/resource_api/lib/puppet/provider/dsc_base_provider/invoke_dsc_resource_postscript.ps1.erb
@@ -1,19 +1,19 @@
-try{
+try {
   $result = Invoke-DscResource @invokeParams
-}catch{
-$response.errormessage   = $_.Exception.Message
-return ($response | ConvertTo-Json -Compress)
+} catch {
+  $response.errormessage   = $_.Exception.Message
+  return ($response | ConvertTo-Json -Compress)
 }
 
 # keep the switch for when Test passes back changed properties
 switch ($invokeParams.Method) {
-'Test' {
-  $response.indesiredstate = $result.InDesiredState
-  return ($response | ConvertTo-Json -Compress)
-}
-'Set' {
-  $response.indesiredstate = $true
-  $response.rebootrequired = $result.RebootRequired
-  return ($response | ConvertTo-Json -Compress)
-}
+  'Test' {
+    $response.indesiredstate = $result.InDesiredState
+    return ($response | ConvertTo-Json -Compress)
+  }
+  'Set' {
+    $response.indesiredstate = $true
+    $response.rebootrequired = $result.RebootRequired
+    return ($response | ConvertTo-Json -Compress)
+  }
 }


### PR DESCRIPTION
This set of commits is fairly heavy and includes some significant refactoring, bug fixing, and improvements.

Highlights include:

- Removal of need for undocumented CSV to specify which module to puppetize
- Fix file encoding of templated files (remove the BOM)
- Update type generation to include whether or not the types are mandatory and include their help information, if discoverable
- Re-use a single method (`invoke_set_method`) for the create, update, and delete calls in the provider
- Ensure the resultant provider implementation is idempotent and can return property-by-property change reporting by implementing the simple_get_filter feature

The build script defaults to creating the Puppet module `powershellget` by vendoring and puppetizing the [PowerShellGet](https://www.powershellgallery.com/packages/PowerShellGet/2.2.3) module from the Gallery (it vendors the dependency module, [PackageManagement](https://www.powershellgallery.com/packages/PackageManagement/1.4.6), as well).

You can test this builder out locally if you have the PDK, Windows PowerShell 5.1, and the [powershell-yaml](https://www.powershellgallery.com/packages/powershell-yaml/0.4.1) and [EPS](https://www.powershellgallery.com/packages/EPS/1.0.0) PowerShell modules installed locally:

```powershell
./build.ps1
Push-Location import/powershellget
pdk bundle install
pdk bundle exec rake spec_prep
```

You'll then want to copy this manifest to your local machine, saved as `PuppetDscBuilder/import/powershellget/examples/basic.pp`:

```puppet
dsc_psrepository {'Add team shared module folder as a repository':
    dsc_name               => 'foo',
    dsc_ensure             => present,
    # This location is nonsense, can be any valid folder on your
    # machine or in a share, any location the SourceLocation param
    # for the DSC resource will accept.
    dsc_sourcelocation     => 'C:\Program Files',
    dsc_installationpolicy => trusted,
}

dsc_psrepository {'Trust the PowerShell Gallery':
    dsc_name               => 'PSGallery',
    dsc_ensure             => present,
    dsc_installationpolicy => trusted,
}

dsc_psmodule {'Ensure Ruby is Manageable via uru':
  dsc_name   => 'RubyInstaller',
  dsc_ensure => absent,
}

```

And then run:

```powershell
pdk bundle exec puppet apply .\examples\basic.pp --modulepath .\spec\fixtures\modules\
```

You can also change one of the settings in `basic.pp` to verify that this implementation gives you property-by-property reporting; try changing the `dsc_installationpolicy` of either of the `dsc_psrepository` resources from `trusted` to `untrusted`.
