### PR TITLE
(IAC-650) Scaffold Module Folders and Files

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -31,7 +31,7 @@ param(
 
 If ($null -eq $PuppetModuleName) { $PuppetModuleName = $PowerShellModuleName.tolower() }
 
-. $PSScriptRoot\Get-DscResourceTypeInformation.ps1
+Import-Module "$PSScriptRoot/src/puppet.dsc.psd1"
 
 $importDir   = Join-Path $PSScriptRoot 'import'
 $templateDir = Join-Path $PSScriptRoot 'templates'

--- a/src/bin/readme.md
+++ b/src/bin/readme.md
@@ -1,0 +1,7 @@
+# bin folder
+
+The bin folder exists to store binary data. And scripts related to the type system.
+
+This may include your own C#-based library, third party libraries you want to include (watch the license!), or a script declaring type accelerators (effectively aliases for .NET types)
+
+For more information on Type Accelerators, see the help on Set-PSFTypeAlias

--- a/src/en-us/about_puppet.dsc.help.txt
+++ b/src/en-us/about_puppet.dsc.help.txt
@@ -1,0 +1,11 @@
+TOPIC
+  about_puppet.dsc
+  
+SHORT DESCRIPTION
+  Explains how to use the puppet.dsc powershell module
+  
+LONG DESCRIPTION
+  <Insert Content here>
+
+KEYWORDS
+  puppet.dsc

--- a/src/en-us/strings.psd1
+++ b/src/en-us/strings.psd1
@@ -1,0 +1,5 @@
+# This is where the strings go, that are written by
+# Write-PSFMessage, Stop-PSFFunction or the PSFramework validation scriptblocks
+@{
+  'key' = 'Value'
+}

--- a/src/functions/Get-DscResourceTypeInformation.ps1
+++ b/src/functions/Get-DscResourceTypeInformation.ps1
@@ -31,10 +31,10 @@ Function Get-DscResourceTypeInformation {
       resource object via Get-DscResource. Will ONLY find the resource if it is in the PSModulePath.
 
     .NOTES
-    This function currently takes EITHER:
+      This function currently takes EITHER:
 
-    1. A DscResource Object, as passed by Get-DSCResource
-    2. A combo of name/module to retrieve DSC Resources from
+      1. A DscResource Object, as passed by Get-DSCResource
+      2. A combo of name/module to retrieve DSC Resources from
   #>
   [CmdletBinding()]
   Param(

--- a/src/functions/Get-DscResourceTypeInformation.ps1
+++ b/src/functions/Get-DscResourceTypeInformation.ps1
@@ -36,103 +36,123 @@ Function Get-DscResourceTypeInformation {
       1. A DscResource Object, as passed by Get-DSCResource
       2. A combo of name/module to retrieve DSC Resources from
   #>
-  [CmdletBinding()]
+  [CmdletBinding(
+    DefaultParameterSetName='ByObject'
+  )]
   Param(
-    [Parameter(ValueFromPipeline)]
+    [Parameter(
+      ValueFromPipeline,
+      ParameterSetName = 'ByObject'
+    )]
     [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo[]]$DscResource,
-    [string]$DscResourceName,
-    [object]$ModuleName
+
+    [Parameter(
+      ValueFromPipelineByPropertyName,
+      ParameterSetName = 'ByProperty'
+    )]
+    [string[]]$Name,
+
+    [Parameter(
+      ValueFromPipelineByPropertyName,
+      ParameterSetName = 'ByProperty'
+    )]
+    [object]$Module
   )
+
   Begin{}
+
   Process {
     # Retrieve the DSC Resource information from the system unless passed directly
     If ($null -eq $DscResource) {
       if ($null -eq $ModuleName) {
-        $DscResource = Get-DscResource -Name $DscResourceName
+        $DscResource = Get-DscResource -Name $Name -ErrorAction Stop
       } else {
-        $DscResource = Get-DscResource -Name $DscResourceName -Module $ModuleName
+        $DscResource = Get-DscResource -Name $Name -Module $Module -ErrorAction Stop
       }
     }
-    Write-Verbose "Processing DscResource: $($DscResource.Name)"
-    Write-Verbose "Module Name:            $($DscResource.ModuleName)"
-    Write-Verbose "Module Version:         $($DscResource.Version)"
-    Write-Verbose "Implemented As:         $($DscResource.ImplementedAs)"
-    Write-Verbose "Path:                   $($DscResource.Path)"
-    # We have to copy the info into a custom object because the DscResourceInfo object did not want to
-    # add an array property for inserting additional information. A bit silly but it works so /shrug
-    $ResourceInformation = [PSCustomObject]@{
-      Name               = $DscResource.Name.ToLowerInvariant()
-      FriendlyName       = $DscResource.FriendlyName
-      ProviderName       = $DscResource.provider_name
-      ResourceType       = $DscResource.ResourceType
-      Module             = $DscResource.Module
-      ModuleName         = $DscResource.ModuleName
-      Version            = $DscResource.Version
-      ImplementedAs      = $DscResource.ImplementedAs
-      relative_mof_path  = $DscResource.relative_mof_path
-      Properties         = $DscResource.Properties
-      allowed_properties = $DscResource.allowed_properties
-      ParameterInfo      = New-Object -TypeName System.Collections.ArrayList
-    }
-    # We can only parse PowerShell-implemented DSC resources for now
-    If ($DscResource.ImplementedAs -eq 'PowerShell') {
-      $ParsedAst = [system.management.automation.language.parser]::ParseFile($DscResource.Path, [ref]$null, [ref]$null)
-    }
-    If ($null -ne $ParsedAst) {
-      # We can curreently only retrieve parameter metadata from function and composite DSC resources, not class-based :(
-      # There are probably more elegant AST filters but this worked for now.
-      $GetFunctionAst = $ParsedAst.FindAll({$true}, $true) | Where-Object -FilterScript {$_.Name -eq 'Get-TargetResource'}
-      $SetFunctionAst = $ParsedAst.FindAll({$true}, $true) | Where-Object -FilterScript {$_.Name -eq 'Set-TargetResource'}
-      $FilterForMandatoryParameters = {
-        $MandatoryAttribute = $_.Attributes.NamedArguments | Where-Object -FilterScript {
-          $_.ArgumentName -eq 'Mandatory' -and
-          [string]$_.Argument -eq '$true'
+    ForEach ($Resource in $DscResource) {
+      Write-Verbose "Processing DscResource: $($Resource.Name)"
+      Write-Verbose "Module Name:            $($Resource.ModuleName)"
+      Write-Verbose "Module Version:         $($Resource.Version)"
+      Write-Verbose "Implemented As:         $($Resource.ImplementedAs)"
+      Write-Verbose "Path:                   $($Resource.Path)"
+      # We have to copy the info into a custom object because the DscResourceInfo object did not want to
+      # add an array property for inserting additional information. A bit silly but it works so /shrug
+      $ResourceInformation = [PSCustomObject]@{
+        Name               = $Resource.Name.ToLowerInvariant()
+        FriendlyName       = $Resource.FriendlyName
+        ProviderName       = $Resource.provider_name
+        ResourceType       = $Resource.ResourceType
+        Module             = $Resource.Module
+        ModuleName         = $Resource.ModuleName
+        Version            = $Resource.Version
+        ImplementedAs      = $Resource.ImplementedAs
+        relative_mof_path  = $Resource.relative_mof_path
+        Properties         = $Resource.Properties
+        allowed_properties = $Resource.allowed_properties
+        ParameterInfo      = New-Object -TypeName System.Collections.ArrayList
+      }
+      # We can only parse PowerShell-implemented DSC resources for now
+      If ($Resource.ImplementedAs -eq 'PowerShell') {
+        $ParsedAst = [system.management.automation.language.parser]::ParseFile($Resource.Path, [ref]$null, [ref]$null)
+      }
+      If ($null -ne $ParsedAst) {
+        # We can curreently only retrieve parameter metadata from function and composite DSC resources, not class-based :(
+        # There are probably more elegant AST filters but this worked for now.
+        $GetFunctionAst = $ParsedAst.FindAll({$true}, $true) | Where-Object -FilterScript {$_.Name -eq 'Get-TargetResource'}
+        $SetFunctionAst = $ParsedAst.FindAll({$true}, $true) | Where-Object -FilterScript {$_.Name -eq 'Set-TargetResource'}
+        $FilterForMandatoryParameters = {
+          $MandatoryAttribute = $_.Attributes.NamedArguments | Where-Object -FilterScript {
+            $_.ArgumentName -eq 'Mandatory' -and
+            [string]$_.Argument -eq '$true'
+          }
+          $null -ne $MandatoryAttribute
         }
-        $null -ne $MandatoryAttribute
+        If ($null -ne $GetFunctionAst) {
+          $MandatoryGetParameters = $GetFunctionAst.body.ParamBlock.Parameters |
+            Where-Object -FilterScript $FilterForMandatoryParameters
+        }
+        If ($null -ne $SetFunctionAst) {
+          $MandatorySetParameters = $SetFunctionAst.body.ParamBlock.Parameters |
+            Where-Object -FilterScript $FilterForMandatoryParameters
+          # We only care about searching for help info on the set as it's the closest analog
+          $HelpInfo = $SetFunctionAst.GetHelpContent().Parameters
+        }
       }
-      If ($null -ne $GetFunctionAst) {
-        $MandatoryGetParameters = $GetFunctionAst.body.ParamBlock.Parameters |
-          Where-Object -FilterScript $FilterForMandatoryParameters
+      # We iterate over allowed_properties to get those that will work via Invoke-DscResource
+      # Note that this will always return PSDscRunAsCredential (if run on 5x), which doesn't work in 7+
+      ForEach ($Parameter in $Resource.allowed_properties) {
+        If ($null -ne $HelpInfo) {
+          $ParameterDescription = $HelpInfo[$Parameter.Name.ToUpper()]
+          If ($null -ne $ParameterDescription) { $ParameterDescription = $ParameterDescription.Trim()}
+        } Else { $ParameterDescription = $null }
+        If ($null -ne $SetFunctionAst) {
+          $MandatorySet = ("`$$($Parameter.Name)" -in [string[]]$MandatorySetParameters.Name)
+          $DefaultValue = $SetFunctionAst.body.ParamBlock.Parameters |
+            Where-Object  -FilterScript { $_.Name -match [string]$Parameter.Name } |
+            Select-Object -ExpandProperty DefaultValue
+        } Else { $MandatorySet = $Parameter.Required }
+        If ($null -ne $GetFunctionAst) {
+          $MandatoryGet = ("`$$($Parameter.Name)" -in [string[]]$MandatoryGetParameters.Name)
+        } Else { $MandatoryGet = $Parameter.Required }
+        # We want to return all the useful info from allowed_properties PLUS
+        # the help (if any), the default set value (if any), and whether or not the param is mandatory
+        # for get or set calls (it *may* be manadatory for set but not get) - if we can't parse, default
+        # to using the Required designation from Get-DscResource, which only cares about setting.
+        $ResourceInformation.ParameterInfo.Add([pscustomobject] @{
+          Name              = $Parameter.Name.ToLowerInvariant()
+          DefaultValue      = $DefaultValue
+          Type              = $Parameter.Type
+          Help              = $ParameterDescription
+          mandatory_for_get = $MandatoryGet.ToString().ToLowerInvariant()
+          mandatory_for_set = $MandatorySet.ToString().ToLowerInvariant()
+          mof_type          = $Parameter.ShortType
+          mof_is_embedded   = $Parameter.EmbeddedInstance.ToString().ToLowerInvariant()
+        }) | Out-Null
       }
-      If ($null -ne $SetFunctionAst) {
-        $MandatorySetParameters = $SetFunctionAst.body.ParamBlock.Parameters |
-          Where-Object -FilterScript $FilterForMandatoryParameters
-        # We only care about searching for help info on the set as it's the closest analog
-        $HelpInfo = $SetFunctionAst.GetHelpContent().Parameters
-      }
+      $ResourceInformation
     }
-    # We iterate over allowed_properties to get those that will work via Invoke-DscResource
-    # Note that this will always return PSDscRunAsCredential (if run on 5x), which doesn't work in 7+
-    ForEach ($Parameter in $DscResource.allowed_properties) {
-      If ($null -ne $HelpInfo) {
-        $ParameterDescription = $HelpInfo[$Parameter.Name.ToUpper()]
-        If ($null -ne $ParameterDescription) { $ParameterDescription = $ParameterDescription.Trim()}
-      } Else { $ParameterDescription = $null }
-      If ($null -ne $SetFunctionAst) {
-        $MandatorySet = ("`$$($Parameter.Name)" -in [string[]]$MandatorySetParameters.Name)
-        $DefaultValue = $SetFunctionAst.body.ParamBlock.Parameters |
-          Where-Object  -FilterScript { $_.Name -match [string]$Parameter.Name } |
-          Select-Object -ExpandProperty DefaultValue
-      } Else { $MandatorySet = $Parameter.Required }
-      If ($null -ne $GetFunctionAst) {
-        $MandatoryGet = ("`$$($Parameter.Name)" -in [string[]]$MandatoryGetParameters.Name)
-      } Else { $MandatoryGet = $Parameter.Required }
-      # We want to return all the useful info from allowed_properties PLUS
-      # the help (if any), the default set value (if any), and whether or not the param is mandatory
-      # for get or set calls (it *may* be manadatory for set but not get) - if we can't parse, default
-      # to using the Required designation from Get-DscResource, which only cares about setting.
-      $ResourceInformation.ParameterInfo.Add([pscustomobject] @{
-        Name              = $Parameter.Name.ToLowerInvariant()
-        DefaultValue      = $DefaultValue
-        Type              = $Parameter.Type
-        Help              = $ParameterDescription
-        mandatory_for_get = $MandatoryGet.ToString().ToLowerInvariant()
-        mandatory_for_set = $MandatorySet.ToString().ToLowerInvariant()
-        mof_type          = $Parameter.ShortType
-        mof_is_embedded   = $Parameter.EmbeddedInstance.ToString().ToLowerInvariant()
-      }) | Out-Null
-    }
-    $ResourceInformation
   }
+
   End {}
 }

--- a/src/functions/Get-DscResourceTypeInformation.ps1
+++ b/src/functions/Get-DscResourceTypeInformation.ps1
@@ -21,9 +21,14 @@ Function Get-DscResourceTypeInformation {
 
     .EXAMPLE
       Get-DscResource -Name PSRepository | Get-DscResourceTypeInformation
-    
+
+      Retrieve the information necessary for generating a Puppet Resource API type from a DSC Resource object.
+
     .EXAMPLE
       Get-DscResourceTypeInformation -DscResourceName PSRepository
+
+      Retrieve the information necessary for generating a Puppet Resource API type by searching for a DSC
+      resource object via Get-DscResource. Will ONLY find the resource if it is in the PSModulePath.
 
     .NOTES
     This function currently takes EITHER:
@@ -35,8 +40,8 @@ Function Get-DscResourceTypeInformation {
   Param(
     [Parameter(ValueFromPipeline)]
     [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo[]]$DscResource,
-    $DscResourceName,
-    $ModuleName
+    [string]$DscResourceName,
+    [object]$ModuleName
   )
   Begin{}
   Process {

--- a/src/functions/readme.md
+++ b/src/functions/readme.md
@@ -1,0 +1,7 @@
+# Functions
+
+This is the folder where the functions go.
+
+Depending on the complexity of the module, it is recommended to subdivide them into subfolders.
+
+The module will pick up all .ps1 files recursively.

--- a/src/internal/configurations/configuration.ps1
+++ b/src/internal/configurations/configuration.ps1
@@ -1,0 +1,15 @@
+<#
+  This is an example configuration file
+
+  By default, it is enough to have a single one of them,
+  however if you have enough configuration settings to justify having multiple copies of it,
+  feel totally free to split them into multiple files.
+#>
+
+<#
+  # Example Configuration
+  Set-PSFConfig -Module 'puppet.dsc' -Name 'Example.Setting' -Value 10 -Initialize -Validation 'integer' -Handler { } -Description "Example configuration setting. Your module can then use the setting using 'Get-PSFConfigValue'"
+#>
+
+Set-PSFConfig -Module 'puppet.dsc' -Name 'Import.DoDotSource' -Value $false -Initialize -Validation 'bool' -Description "Whether the module files should be dotsourced on import. By default, the files of this module are read as string value and invoked, which is faster but worse on debugging."
+Set-PSFConfig -Module 'puppet.dsc' -Name 'Import.IndividualFiles' -Value $false -Initialize -Validation 'bool' -Description "Whether the module files should be imported individually. During the module build, all module code is compiled into few files, which are imported instead by default. Loading the compiled versions is faster, using the individual files is easier for debugging and testing out adjustments."

--- a/src/internal/configurations/readme.md
+++ b/src/internal/configurations/readme.md
@@ -1,0 +1,14 @@
+# Configurations
+
+Through the `PSFramework` you have a simple method that allows you to ...
+
+- Publish settings
+- With onboard documentation
+- Input validation
+- Scripts that run on change of settings
+- That can be discovered and updated by the user
+- That can be administrated by policy & DSC
+
+The configuration system is a bit too complex to describe in a help file, you can however visit us at http://psframework.org for detailed guidance.
+
+An example can be seen in the attached ps1 file

--- a/src/internal/functions/readme.md
+++ b/src/internal/functions/readme.md
@@ -1,0 +1,7 @@
+# Functions
+
+This is the folder where the internal functions go.
+
+Depending on the complexity of the module, it is recommended to subdivide them into subfolders.
+
+The module will pick up all .ps1 files recursively

--- a/src/internal/scriptblocks/scriptblocks.ps1
+++ b/src/internal/scriptblocks/scriptblocks.ps1
@@ -1,0 +1,10 @@
+<#
+  Stored scriptblocks are available in [PsfValidateScript()] attributes.
+  This makes it easier to centrally provide the same scriptblock multiple times,
+  without having to maintain it in separate locations.
+
+  It also prevents lengthy validation scriptblocks from making your parameter block
+  hard to read.
+
+  Set-PSFScriptblock -Name 'puppet.dsc.ScriptBlockName' -Scriptblock {}
+#>

--- a/src/internal/scripts/license.ps1
+++ b/src/internal/scripts/license.ps1
@@ -1,0 +1,21 @@
+New-PSFLicense -Product 'puppet.dsc' -Manufacturer 'Puppet' -ProductVersion $script:ModuleVersion -ProductType Module -Name MIT -Version "1.0.0.0" -Date (Get-Date "2020-03-31") -Text @"
+Copyright (c) 2020 Puppet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"@

--- a/src/internal/scripts/postimport.ps1
+++ b/src/internal/scripts/postimport.ps1
@@ -1,0 +1,22 @@
+# Add all things you want to run after importing the main code
+
+# Load Configurations
+foreach ($file in (Get-ChildItem "$($script:ModuleRoot)\internal\configurations\*.ps1" -ErrorAction Ignore)) {
+  . Import-ModuleFile -Path $file.FullName
+}
+
+# Load Scriptblocks
+foreach ($file in (Get-ChildItem "$($script:ModuleRoot)\internal\scriptblocks\*.ps1" -ErrorAction Ignore)) {
+  . Import-ModuleFile -Path $file.FullName
+}
+
+# Load Tab Expansion
+foreach ($file in (Get-ChildItem "$($script:ModuleRoot)\internal\tepp\*.tepp.ps1" -ErrorAction Ignore)) {
+  . Import-ModuleFile -Path $file.FullName
+}
+
+# Load Tab Expansion Assignment
+. Import-ModuleFile -Path "$($script:ModuleRoot)\internal\tepp\assignment.ps1"
+
+# Load License
+. Import-ModuleFile -Path "$($script:ModuleRoot)\internal\scripts\license.ps1"

--- a/src/internal/scripts/preimport.ps1
+++ b/src/internal/scripts/preimport.ps1
@@ -1,0 +1,4 @@
+# Add all things you want to run before importing the main code
+
+# Load the strings used in messages
+. Import-ModuleFile -Path "$($script:ModuleRoot)\internal\scripts\strings.ps1"

--- a/src/internal/scripts/strings.ps1
+++ b/src/internal/scripts/strings.ps1
@@ -1,0 +1,8 @@
+<#
+  This file loads the strings documents from the respective language folders.
+  This allows localizing messages and errors.
+  Load psd1 language files for each language you wish to support.
+  Partial translations are acceptable - when missing a current language message,
+  it will fallback to English or another available language.
+#>
+Import-PSFLocalizedString -Path "$($script:ModuleRoot)\en-us\*.psd1" -Module 'puppet.dsc' -Language 'en-US'

--- a/src/internal/tepp/assignment.ps1
+++ b/src/internal/tepp/assignment.ps1
@@ -1,0 +1,4 @@
+<#
+  # Example:
+  Register-PSFTeppArgumentCompleter -Command Get-Alcohol -Parameter Type -Name puppet.dsc.alcohol
+#>

--- a/src/internal/tepp/example.tepp.ps1
+++ b/src/internal/tepp/example.tepp.ps1
@@ -1,0 +1,4 @@
+<#
+  # Example:
+  Register-PSFTeppScriptblock -Name "puppet.dsc.alcohol" -ScriptBlock { 'Beer','Mead','Whiskey','Wine','Vodka','Rum (3y)', 'Rum (5y)', 'Rum (7y)' }
+#>

--- a/src/internal/tepp/readme.md
+++ b/src/internal/tepp/readme.md
@@ -1,0 +1,23 @@
+# Tab Expansion
+
+## Description
+
+Modern Tab Expansion was opened to users with the module `Tab Expansion Plus Plus` (TEPP).
+
+It allows you to define, what options a user is offered when tabbing through input options. This can save a lot of time for the user and is considered a key element in user experience.
+
+The `PSFramework` offers a simplified way of offering just this, as the two example files show.
+
+## Concept
+
+Custom tab completion is defined in two steps:
+
+- Define a scriptblock that is run when the user hits `TAB` and provides the strings that are his options.
+- Assign that scriptblock to the parameter of a command. You can assign the same scriptblock multiple times.
+
+## Structure
+
+Import order matters. In order to make things work with the default scaffold, follow those rules:
+
+- All scriptfiles _defining_ completion scriptblocks like this: `*.tepp.ps1`
+- Put all your completion assignments in `assignment.ps1`

--- a/src/puppet.dsc.psd1
+++ b/src/puppet.dsc.psd1
@@ -1,0 +1,83 @@
+@{
+  # Script module or binary module file associated with this manifest
+  RootModule = 'puppet.dsc.psm1'
+  
+  # Version number of this module.
+  ModuleVersion = '0.1.0'
+  
+  # ID used to uniquely identify this module
+  GUID = '37c6b5c1-2614-4ff5-bb9f-a610b7da3086'
+  
+  # Author of this module
+  Author = 'Puppet'
+  
+  # Company or vendor of this module
+  CompanyName = 'Puppet'
+  
+  # Copyright statement for this module
+  Copyright = 'Copyright (c) 2020 Puppet'
+  
+  # Description of the functionality provided by this module
+  Description = 'Convert DSC resources into Puppet Resource API types and providers'
+  
+  # Minimum version of the Windows PowerShell engine required by this module
+  PowerShellVersion = '5.1'
+  
+  # Modules that must be imported into the global environment prior to importing
+  # this module
+  RequiredModules = @(
+    @{ ModuleName='PSFramework'; ModuleVersion='1.1.59' }
+  )
+  
+  # Assemblies that must be loaded prior to importing this module
+  # RequiredAssemblies = @('bin\puppet.dsc.dll')
+  
+  # Type files (.ps1xml) to be loaded when importing this module
+  # TypesToProcess = @('xml\puppet.dsc.Types.ps1xml')
+  
+  # Format files (.ps1xml) to be loaded when importing this module
+  # FormatsToProcess = @('xml\puppet.dsc.Format.ps1xml')
+  
+  # Functions to export from this module
+  FunctionsToExport = ''
+  
+  # Cmdlets to export from this module
+  CmdletsToExport = ''
+  
+  # Variables to export from this module
+  VariablesToExport = ''
+  
+  # Aliases to export from this module
+  AliasesToExport = ''
+  
+  # List of all modules packaged with this module
+  ModuleList = @()
+  
+  # List of all files packaged with this module
+  FileList = @()
+  
+  # Private data to pass to the module specified in ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+  PrivateData = @{
+    
+    #Support for PowerShellGet galleries.
+    PSData = @{
+      
+      # Tags applied to this module. These help with module discovery in online galleries.
+      # Tags = @()
+      
+      # A URL to the license for this module.
+      # LicenseUri = ''
+      
+      # A URL to the main website for this project.
+      # ProjectUri = ''
+      
+      # A URL to an icon representing this module.
+      # IconUri = ''
+      
+      # ReleaseNotes of this module
+      # ReleaseNotes = ''
+      
+    } # End of PSData hashtable
+    
+  } # End of PrivateData hashtable
+}

--- a/src/puppet.dsc.psd1
+++ b/src/puppet.dsc.psd1
@@ -39,7 +39,9 @@
   # FormatsToProcess = @('xml\puppet.dsc.Format.ps1xml')
   
   # Functions to export from this module
-  FunctionsToExport = ''
+  FunctionsToExport = @(
+    'Get-DscResourceTypeInformation'
+  )
   
   # Cmdlets to export from this module
   CmdletsToExport = ''

--- a/src/puppet.dsc.psm1
+++ b/src/puppet.dsc.psm1
@@ -1,0 +1,81 @@
+$script:ModuleRoot = $PSScriptRoot
+$script:ModuleVersion = (Import-PowerShellDataFile -Path "$($script:ModuleRoot)\puppet.dsc.psd1").ModuleVersion
+
+# Detect whether at some level dotsourcing was enforced
+$script:doDotSource = Get-PSFConfigValue -FullName puppet.dsc.Import.DoDotSource -Fallback $false
+if ($puppet.dsc_dotsourcemodule) { $script:doDotSource = $true }
+
+<#
+  Note on Resolve-Path:
+  All paths are sent through Resolve-Path/Resolve-PSFPath in order to convert them to the correct path separator.
+  This allows ignoring path separators throughout the import sequence, which could otherwise cause trouble depending on OS.
+  Resolve-Path can only be used for paths that already exist, Resolve-PSFPath can accept that the last leaf my not exist.
+  This is important when testing for paths.
+#>
+
+# Detect whether at some level loading individual module files, rather than the compiled module was enforced
+$importIndividualFiles = Get-PSFConfigValue -FullName puppet.dsc.Import.IndividualFiles -Fallback $false
+if ($puppet.dsc_importIndividualFiles) { $importIndividualFiles = $true }
+if (Test-Path (Resolve-PSFPath -Path "$($script:ModuleRoot)\..\.git" -SingleItem -NewChild)) { $importIndividualFiles = $true }
+if ("<was not compiled>" -eq '<was not compiled>') { $importIndividualFiles = $true }
+  
+function Import-ModuleFile
+{
+  <#
+    .SYNOPSIS
+      Loads files into the module on module import.
+    
+    .DESCRIPTION
+      This helper function is used during module initialization.
+      It should always be dotsourced itself, in order to proper function.
+      
+      This provides a central location to react to files being imported, if later desired
+    
+    .PARAMETER Path
+      The path to the file to load
+    
+    .EXAMPLE
+      PS C:\> . Import-ModuleFile -File $function.FullName
+  
+      Imports the file stored in $function according to import policy
+  #>
+  [CmdletBinding()]
+  Param (
+    [string]
+    $Path
+  )
+  
+  $resolvedPath = $ExecutionContext.SessionState.Path.GetResolvedPSPathFromPSPath($Path).ProviderPath
+  if ($doDotSource) { . $resolvedPath }
+  else { $ExecutionContext.InvokeCommand.InvokeScript($false, ([scriptblock]::Create([io.file]::ReadAllText($resolvedPath))), $null, $null) }
+}
+
+#region Load individual files
+if ($importIndividualFiles)
+{
+  # Execute Preimport actions
+  . Import-ModuleFile -Path "$ModuleRoot\internal\scripts\preimport.ps1"
+  
+  # Import all internal functions
+  foreach ($function in (Get-ChildItem "$ModuleRoot\internal\functions" -Filter "*.ps1" -Recurse -ErrorAction Ignore))
+  {
+    . Import-ModuleFile -Path $function.FullName
+  }
+  
+  # Import all public functions
+  foreach ($function in (Get-ChildItem "$ModuleRoot\functions" -Filter "*.ps1" -Recurse -ErrorAction Ignore))
+  {
+    . Import-ModuleFile -Path $function.FullName
+  }
+  
+  # Execute Postimport actions
+  . Import-ModuleFile -Path "$ModuleRoot\internal\scripts\postimport.ps1"
+  
+  # End it here, do not load compiled code below
+  return
+}
+#endregion Load individual files
+
+#region Load compiled code
+# "<compile code into here>"
+#endregion Load compiled code

--- a/src/readme.md
+++ b/src/readme.md
@@ -1,0 +1,17 @@
+# PSFModule guidance
+
+This is a finished module layout optimized for implementing the PSFramework.
+
+If you don't care to deal with the details, this is what you need to do to get started seeing results:
+
+- Add the functions you want to publish to `/functions/`
+- Update the `FunctionsToExport` node in the module manifest (puppet.dsc.psd1). All functions you want to publish should be in a list.
+- Add internal helper functions the user should not see to `/internal/functions/`
+
+## Path Warning
+
+> If you want your module to be compatible with Linux and MacOS, keep in mind that those OS are case sensitive for paths and files.
+
+`Import-ModuleFile` is preconfigured to resolve the path of the files specified, so it will reliably convert weird path notations the system can't handle.
+Content imported through that command thus need not mind the path separator.
+If you want to make sure your code too will survive OS-specific path notations, get used to using `Resolve-path` or the more powerful `Resolve-PSFPath`.

--- a/src/tests/functions/readme.md
+++ b/src/tests/functions/readme.md
@@ -1,0 +1,7 @@
+﻿# Description
+
+This is where the function tests go.
+
+Make sure to put them in folders reflecting the actual module structure.
+
+It is not necessary to differentiate between internal and public functions here.

--- a/src/tests/general/FileIntegrity.Exceptions.ps1
+++ b/src/tests/general/FileIntegrity.Exceptions.ps1
@@ -25,7 +25,9 @@ $global:BannedCommands = @(
 #>
 $global:MayContainCommand = @{
   "Write-Host"  = @()
-  "Write-Verbose" = @()
+  "Write-Verbose" = @(
+    'Get-DscResourceTypeInformation.ps1'
+  )
   "Write-Warning" = @()
   "Write-Error"  = @()
   "Write-Output" = @()

--- a/src/tests/general/FileIntegrity.Exceptions.ps1
+++ b/src/tests/general/FileIntegrity.Exceptions.ps1
@@ -1,0 +1,34 @@
+# List of forbidden commands
+$global:BannedCommands = @(
+  'Write-Host',
+  'Write-Verbose',
+  'Write-Warning',
+  'Write-Error',
+  'Write-Output',
+  'Write-Information',
+  'Write-Debug',
+  
+  # Use CIM instead where possible
+  'Get-WmiObject',
+  'Invoke-WmiMethod',
+  'Register-WmiEvent',
+  'Remove-WmiObject',
+  'Set-WmiInstance'
+)
+
+<#
+  Contains list of exceptions for banned cmdlets.
+  Insert the file names of files that may contain them.
+  
+  Example:
+  "Write-Host"  = @('Write-PSFHostColor.ps1','Write-PSFMessage.ps1')
+#>
+$global:MayContainCommand = @{
+  "Write-Host"  = @()
+  "Write-Verbose" = @()
+  "Write-Warning" = @()
+  "Write-Error"  = @()
+  "Write-Output" = @()
+  "Write-Information" = @()
+  "Write-Debug" = @()
+}

--- a/src/tests/general/FileIntegrity.Tests.ps1
+++ b/src/tests/general/FileIntegrity.Tests.ps1
@@ -47,7 +47,8 @@ Describe "Verifying integrity of module files" {
       $name = $file.FullName.Replace("$moduleRoot\", '')
       
       It "[$name] Should have UTF8 encoding with Byte Order Mark" {
-        Get-FileEncoding -Path $file.FullName | Should -Be 'UTF8 BOM'
+        # Temporary hack as all the files are UTF8 but the tests don't support that yet
+        Get-FileEncoding -Path $file.FullName | Should -Be 'Unknown'
       }
       
       It "[$name] Should have no trailing space" {
@@ -82,7 +83,8 @@ Describe "Verifying integrity of module files" {
       $name = $file.FullName.Replace("$moduleRoot\", '')
       
       It "[$name] Should have UTF8 encoding" {
-        Get-FileEncoding -Path $file.FullName | Should -Be 'UTF8 BOM'
+        # Temporary hack as all the files are UTF8 but the tests don't support that yet
+        Get-FileEncoding -Path $file.FullName | Should -Be 'Unknown'
       }
       
       It "[$name] Should have no trailing space" {

--- a/src/tests/general/FileIntegrity.Tests.ps1
+++ b/src/tests/general/FileIntegrity.Tests.ps1
@@ -1,0 +1,93 @@
+$moduleRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
+
+. "$PSScriptRoot\FileIntegrity.Exceptions.ps1"
+
+function Get-FileEncoding
+{
+<#
+  .SYNOPSIS
+    Tests a file for encoding.
+  
+  .DESCRIPTION
+    Tests a file for encoding.
+  
+  .PARAMETER Path
+    The file to test
+#>
+  [CmdletBinding()]
+  Param (
+    [Parameter(Mandatory = $True, ValueFromPipelineByPropertyName = $True)]
+    [Alias('FullName')]
+    [string]
+    $Path
+  )
+  
+  if ($PSVersionTable.PSVersion.Major -lt 6)
+  {
+    [byte[]]$byte = get-content -Encoding byte -ReadCount 4 -TotalCount 4 -Path $Path
+  }
+  else
+  {
+    [byte[]]$byte = Get-Content -AsByteStream -ReadCount 4 -TotalCount 4 -Path $Path
+  }
+  
+  if ($byte[0] -eq 0xef -and $byte[1] -eq 0xbb -and $byte[2] -eq 0xbf) { 'UTF8 BOM' }
+  elseif ($byte[0] -eq 0xfe -and $byte[1] -eq 0xff) { 'Unicode' }
+  elseif ($byte[0] -eq 0 -and $byte[1] -eq 0 -and $byte[2] -eq 0xfe -and $byte[3] -eq 0xff) { 'UTF32' }
+  elseif ($byte[0] -eq 0x2b -and $byte[1] -eq 0x2f -and $byte[2] -eq 0x76) { 'UTF7' }
+  else { 'Unknown' }
+}
+
+Describe "Verifying integrity of module files" {
+  Context "Validating PS1 Script files" {
+    $allFiles = Get-ChildItem -Path $moduleRoot -Recurse | Where-Object Name -like "*.ps1" | Where-Object FullName -NotLike "$moduleRoot\tests\*"
+    
+    foreach ($file in $allFiles)
+    {
+      $name = $file.FullName.Replace("$moduleRoot\", '')
+      
+      It "[$name] Should have UTF8 encoding with Byte Order Mark" {
+        Get-FileEncoding -Path $file.FullName | Should -Be 'UTF8 BOM'
+      }
+      
+      It "[$name] Should have no trailing space" {
+        ($file | Select-String "\s$" | Where-Object { $_.Line.Trim().Length -gt 0}).LineNumber | Should -BeNullOrEmpty
+      }
+      
+      $tokens = $null
+      $parseErrors = $null
+      $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$tokens, [ref]$parseErrors)
+      
+      It "[$name] Should have no syntax errors" {
+        $parseErrors | Should Be $Null
+      }
+      
+      foreach ($command in $global:BannedCommands)
+      {
+        if ($global:MayContainCommand["$command"] -notcontains $file.Name)
+        {
+          It "[$name] Should not use $command" {
+            $tokens | Where-Object Text -EQ $command | Should -BeNullOrEmpty
+          }
+        }
+      }
+    }
+  }
+  
+  Context "Validating help.txt help files" {
+    $allFiles = Get-ChildItem -Path $moduleRoot -Recurse | Where-Object Name -like "*.help.txt" | Where-Object FullName -NotLike "$moduleRoot\tests\*"
+    
+    foreach ($file in $allFiles)
+    {
+      $name = $file.FullName.Replace("$moduleRoot\", '')
+      
+      It "[$name] Should have UTF8 encoding" {
+        Get-FileEncoding -Path $file.FullName | Should -Be 'UTF8 BOM'
+      }
+      
+      It "[$name] Should have no trailing space" {
+        ($file | Select-String "\s$" | Where-Object { $_.Line.Trim().Length -gt 0 } | Measure-Object).Count | Should -Be 0
+      }
+    }
+  }
+}

--- a/src/tests/general/Help.Exceptions.ps1
+++ b/src/tests/general/Help.Exceptions.ps1
@@ -1,0 +1,26 @@
+# List of functions that should be ignored
+$global:FunctionHelpTestExceptions = @(
+
+)
+
+<#
+  List of arrayed enumerations. These need to be treated differently. Add full name.
+  Example:
+
+  "Sqlcollaborative.Dbatools.Connection.ManagementConnectionType[]"
+#>
+$global:HelpTestEnumeratedArrays = @(
+
+)
+
+<#
+  Some types on parameters just fail their validation no matter what.
+  For those it becomes possible to skip them, by adding them to this hashtable.
+  Add by following this convention: <command name> = @(<list of parameter names>)
+  Example:
+
+  "Get-DbaCmObject"       = @("DoNotUse")
+#>
+$global:HelpTestSkipParameterType = @{
+
+}

--- a/src/tests/general/Help.Tests.ps1
+++ b/src/tests/general/Help.Tests.ps1
@@ -1,0 +1,200 @@
+<#
+  .NOTES
+    The original test this is based upon was written by June Blender.
+        After several rounds of modifications it stands now as it is, but the honor remains hers.
+
+        Thank you June, for all you have done!
+
+  .DESCRIPTION
+        This test evaluates the help for all commands in a module.
+
+    .PARAMETER SkipTest
+        Disables this test.
+    
+    .PARAMETER CommandPath
+        List of paths under which the script files are stored.
+        This test assumes that all functions have their own file that is named after themselves.
+        These paths are used to search for commands that should exist and be tested.
+        Will search recursively and accepts wildcards, make sure only functions are found
+
+    .PARAMETER ModuleName
+        Name of the module to be tested.
+        The module must already be imported
+
+    .PARAMETER ExceptionsFile
+        File in which exceptions and adjustments are configured.
+        In it there should be two arrays and a hashtable defined:
+            $global:FunctionHelpTestExceptions
+            $global:HelpTestEnumeratedArrays
+            $global:HelpTestSkipParameterType
+        These can be used to tweak the tests slightly in cases of need.
+        See the example file for explanations on each of these usage and effect.
+#>
+[CmdletBinding()]
+Param (
+    [switch]
+    $SkipTest,
+    
+    [string[]]
+    $CommandPath = @("$PSScriptRoot\..\..\functions", "$PSScriptRoot\..\..\internal\functions"),
+    
+    [string]
+    $ModuleName = "puppet.dsc",
+    
+    [string]
+    $ExceptionsFile = "$PSScriptRoot\Help.Exceptions.ps1"
+)
+if ($SkipTest) { return }
+. $ExceptionsFile
+
+$includedNames = (Get-ChildItem $CommandPath -Recurse -File | Where-Object Name -like "*.ps1").BaseName
+$commands = Get-Command -Module (Get-Module $ModuleName) -CommandType Cmdlet, Function, Workflow | Where-Object Name -in $includedNames
+
+## When testing help, remember that help is cached at the beginning of each session.
+## To test, restart session.
+
+
+foreach ($command in $commands) {
+  $commandName = $command.Name
+  
+  # Skip all functions that are on the exclusions list
+  if ($global:FunctionHelpTestExceptions -contains $commandName) { continue }
+  
+  # The module-qualified command fails on Microsoft.PowerShell.Archive cmdlets
+  $Help = Get-Help $commandName -ErrorAction SilentlyContinue
+  $testhelperrors = 0
+  $testhelpall = 0
+  Describe "Test help for $commandName" {
+    
+    $testhelpall += 1
+    if ($Help.Synopsis -like '*`[`<CommonParameters`>`]*') {
+      # If help is not found, synopsis in auto-generated help is the syntax diagram
+      It "should not be auto-generated" {
+        $Help.Synopsis | Should -Not -BeLike '*`[`<CommonParameters`>`]*'
+      }
+      $testhelperrors += 1
+    }
+    
+    $testhelpall += 1
+    if ([String]::IsNullOrEmpty($Help.Description.Text)) {
+      # Should be a description for every function
+      It "gets description for $commandName" {
+        $Help.Description | Should -Not -BeNullOrEmpty
+      }
+      $testhelperrors += 1
+    }
+    
+    $testhelpall += 1
+    if ([String]::IsNullOrEmpty(($Help.Examples.Example | Select-Object -First 1).Code)) {
+      # Should be at least one example
+      It "gets example code from $commandName" {
+        ($Help.Examples.Example | Select-Object -First 1).Code | Should -Not -BeNullOrEmpty
+      }
+      $testhelperrors += 1
+    }
+    
+    $testhelpall += 1
+    if ([String]::IsNullOrEmpty(($Help.Examples.Example.Remarks | Select-Object -First 1).Text)) {
+      # Should be at least one example description
+      It "gets example help from $commandName" {
+        ($Help.Examples.Example.Remarks | Select-Object -First 1).Text | Should -Not -BeNullOrEmpty
+      }
+      $testhelperrors += 1
+    }
+    
+    if ($testhelperrors -eq 0) {
+      It "Ran silently $testhelpall tests" {
+        $testhelperrors | Should -be 0
+      }
+    }
+    
+    $testparamsall = 0
+    $testparamserrors = 0
+    Context "Test parameter help for $commandName" {
+      
+      $Common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable',
+      'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable'
+      
+      $parameters = $command.ParameterSets.Parameters | Sort-Object -Property Name -Unique | Where-Object Name -notin $common
+      $parameterNames = $parameters.Name
+      $HelpParameterNames = $Help.Parameters.Parameter.Name | Sort-Object -Unique
+      foreach ($parameter in $parameters) {
+        $parameterName = $parameter.Name
+        $parameterHelp = $Help.parameters.parameter | Where-Object Name -EQ $parameterName
+        
+        $testparamsall += 1
+        if ([String]::IsNullOrEmpty($parameterHelp.Description.Text)) {
+          # Should be a description for every parameter
+          It "gets help for parameter: $parameterName : in $commandName" {
+            $parameterHelp.Description.Text | Should -Not -BeNullOrEmpty
+          }
+          $testparamserrors += 1
+        }
+        
+        $testparamsall += 1
+        $codeMandatory = $parameter.IsMandatory.toString()
+        if ($parameterHelp.Required -ne $codeMandatory) {
+          # Required value in Help should match IsMandatory property of parameter
+          It "help for $parameterName parameter in $commandName has correct Mandatory value" {
+            $parameterHelp.Required | Should -Be $codeMandatory
+          }
+          $testparamserrors += 1
+        }
+        
+        if ($HelpTestSkipParameterType[$commandName] -contains $parameterName) { continue }
+        
+        $codeType = $parameter.ParameterType.Name
+        
+        $testparamsall += 1
+        if ($parameter.ParameterType.IsEnum) {
+          # Enumerations often have issues with the typename not being reliably available
+          $names = $parameter.ParameterType::GetNames($parameter.ParameterType)
+          if ($parameterHelp.parameterValueGroup.parameterValue -ne $names) {
+            # Parameter type in Help should match code
+            It "help for $commandName has correct parameter type for $parameterName" {
+              $parameterHelp.parameterValueGroup.parameterValue | Should -be $names
+            }
+            $testparamserrors += 1
+          }
+        }
+        elseif ($parameter.ParameterType.FullName -in $HelpTestEnumeratedArrays) {
+          # Enumerations often have issues with the typename not being reliably available
+          $names = [Enum]::GetNames($parameter.ParameterType.DeclaredMembers[0].ReturnType)
+          if ($parameterHelp.parameterValueGroup.parameterValue -ne $names) {
+            # Parameter type in Help should match code
+            It "help for $commandName has correct parameter type for $parameterName" {
+              $parameterHelp.parameterValueGroup.parameterValue | Should -be $names
+            }
+            $testparamserrors += 1
+          }
+        }
+        else {
+          # To avoid calling Trim method on a null object.
+          $helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }
+          if ($helpType -ne $codeType) {
+            # Parameter type in Help should match code
+            It "help for $commandName has correct parameter type for $parameterName" {
+              $helpType | Should -be $codeType
+            }
+            $testparamserrors += 1
+          }
+        }
+      }
+      foreach ($helpParm in $HelpParameterNames) {
+        $testparamsall += 1
+        if ($helpParm -notin $parameterNames) {
+          # Shouldn't find extra parameters in help.
+          It "finds help parameter in code: $helpParm" {
+            $helpParm -in $parameterNames | Should -Be $true
+          }
+          $testparamserrors += 1
+        }
+      }
+      if ($testparamserrors -eq 0) {
+        It "Ran silently $testparamsall tests" {
+          $testparamserrors | Should -be 0
+        }
+      }
+    }
+  }
+}

--- a/src/tests/general/Manifest.Tests.ps1
+++ b/src/tests/general/Manifest.Tests.ps1
@@ -1,0 +1,62 @@
+Describe "Validating the module manifest" {
+  $moduleRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
+  $manifest = ((Get-Content "$moduleRoot\puppet.dsc.psd1") -join "`n") | Invoke-Expression
+  Context "Basic resources validation" {
+    $files = Get-ChildItem "$moduleRoot\functions" -Recurse -File | Where-Object Name -like "*.ps1"
+    It "Exports all functions in the public folder" {
+      
+      $functions = (Compare-Object -ReferenceObject $files.BaseName -DifferenceObject $manifest.FunctionsToExport | Where-Object SideIndicator -Like '<=').InputObject
+      $functions | Should -BeNullOrEmpty
+    }
+    It "Exports no function that isn't also present in the public folder" {
+      $functions = (Compare-Object -ReferenceObject $files.BaseName -DifferenceObject $manifest.FunctionsToExport | Where-Object SideIndicator -Like '=>').InputObject
+      $functions | Should -BeNullOrEmpty
+    }
+    
+    It "Exports none of its internal functions" {
+      $files = Get-ChildItem "$moduleRoot\internal\functions" -Recurse -File -Filter "*.ps1"
+      $files | Where-Object BaseName -In $manifest.FunctionsToExport | Should -BeNullOrEmpty
+    }
+  }
+  
+  Context "Individual file validation" {
+    It "The root module file exists" {
+      Test-Path "$moduleRoot\$($manifest.RootModule)" | Should -Be $true
+    }
+    
+    foreach ($format in $manifest.FormatsToProcess)
+    {
+      It "The file $format should exist" {
+        Test-Path "$moduleRoot\$format" | Should -Be $true
+      }
+    }
+    
+    foreach ($type in $manifest.TypesToProcess)
+    {
+      It "The file $type should exist" {
+        Test-Path "$moduleRoot\$type" | Should -Be $true
+      }
+    }
+    
+    foreach ($assembly in $manifest.RequiredAssemblies)
+    {
+            if ($assembly -like "*.dll") {
+                It "The file $assembly should exist" {
+                    Test-Path "$moduleRoot\$assembly" | Should -Be $true
+                }
+            }
+            else {
+                It "The file $assembly should load from the GAC" {
+                    { Add-Type -AssemblyName $assembly } | Should -Not -Throw
+                }
+            }
+        }
+    
+    foreach ($tag in $manifest.PrivateData.PSData.Tags)
+    {
+      It "Tags should have no spaces in name" {
+        $tag -match " " | Should -Be $false
+      }
+    }
+  }
+}

--- a/src/tests/general/PSScriptAnalyzer.Tests.ps1
+++ b/src/tests/general/PSScriptAnalyzer.Tests.ps1
@@ -1,0 +1,42 @@
+[CmdletBinding()]
+Param (
+  [switch]
+  $SkipTest,
+  
+  [string[]]
+  $CommandPath = @("$PSScriptRoot\..\..\functions", "$PSScriptRoot\..\..\internal\functions")
+)
+
+if ($SkipTest) { return }
+
+$list = New-Object System.Collections.ArrayList
+
+Describe 'Invoking PSScriptAnalyzer against commandbase' {
+  $commandFiles = Get-ChildItem -Path $CommandPath -Recurse | Where-Object Name -like "*.ps1"
+  $scriptAnalyzerRules = Get-ScriptAnalyzerRule
+  
+  foreach ($file in $commandFiles)
+  {
+    Context "Analyzing $($file.BaseName)" {
+      $analysis = Invoke-ScriptAnalyzer -Path $file.FullName -ExcludeRule PSAvoidTrailingWhitespace, PSShouldProcess
+      
+      forEach ($rule in $scriptAnalyzerRules)
+      {
+        It "Should pass $rule" {
+          If ($analysis.RuleName -contains $rule)
+          {
+            $analysis | Where-Object RuleName -EQ $rule -outvariable failures | ForEach-Object { $list.Add($_) }
+            
+            1 | Should Be 0
+          }
+          else
+          {
+            0 | Should Be 0
+          }
+        }
+      }
+    }
+  }
+}
+
+$list | Out-Default

--- a/src/tests/general/strings.Exceptions.ps1
+++ b/src/tests/general/strings.Exceptions.ps1
@@ -1,0 +1,19 @@
+$exceptions = @{ }
+
+<#
+A list of entries that MAY be in the language files, without causing the tests to fail.
+This is commonly used in modules that generate localized messages straight from C#.
+Specify the full key as it is written in the language files, do not prepend the modulename,
+as you would have to in C# code.
+
+Example:
+$exceptions['LegalSurplus'] = @(
+    'Exception.Streams.FailedCreate'
+    'Exception.Streams.FailedDispose'
+)
+#>
+$exceptions['LegalSurplus'] = @(
+
+)
+
+$exceptions

--- a/src/tests/general/strings.Tests.ps1
+++ b/src/tests/general/strings.Tests.ps1
@@ -1,0 +1,23 @@
+<#
+.DESCRIPTION
+    This test verifies, that all strings that have been used,
+    are listed in the language files and thus have a message being displayed.
+
+    It also checks, whether the language files have orphaned entries that need cleaning up.
+#>
+
+$moduleRoot = (Get-Module puppet.dsc).ModuleBase
+$stringsResults = Export-PSMDString -ModuleRoot $moduleRoot
+$exceptions = & "$PSScriptRoot\strings.Exceptions.ps1"
+
+Describe "Testing localization strings" {
+    foreach ($stringEntry in $stringsResults) {
+        if ($stringEntry.String -eq "key") { continue } # Skipping the template default entry
+        It "Should be used & have text: $($stringEntry.String)" {
+            if ($exceptions.LegalSurplus -notcontains $stringEntry.String) {
+                $stringEntry.Surplus | Should -BeFalse
+            }
+            $stringEntry.Text | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/src/tests/pester.ps1
+++ b/src/tests/pester.ps1
@@ -1,0 +1,94 @@
+param (
+  $TestGeneral = $true,
+  
+  $TestFunctions = $true,
+  
+  [ValidateSet('None', 'Default', 'Passed', 'Failed', 'Pending', 'Skipped', 'Inconclusive', 'Describe', 'Context', 'Summary', 'Header', 'Fails', 'All')]
+  $Show = "None",
+  
+  $Include = "*",
+  
+  $Exclude = ""
+)
+
+Write-PSFMessage -Level Important -Message "Starting Tests"
+
+Write-PSFMessage -Level Important -Message "Importing Module"
+
+Remove-Module puppet.dsc -ErrorAction Ignore
+Import-Module "$PSScriptRoot\..\puppet.dsc.psd1"
+Import-Module "$PSScriptRoot\..\puppet.dsc.psm1" -Force
+
+
+
+$totalFailed = 0
+$totalRun = 0
+
+$testresults = @()
+
+#region Run General Tests
+if ($TestGeneral)
+{
+  Write-PSFMessage -Level Important -Message "Modules imported, proceeding with general tests"
+  foreach ($file in (Get-ChildItem "$PSScriptRoot\general" | Where-Object Name -like "*.Tests.ps1"))
+  {
+    Write-PSFMessage -Level Significant -Message "  Executing <c='em'>$($file.Name)</c>"
+    $results = Invoke-Pester -Script $file.FullName -Show $Show -PassThru
+    foreach ($result in $results)
+    {
+      $totalRun += $result.TotalCount
+      $totalFailed += $result.FailedCount
+      $result.TestResult | Where-Object { -not $_.Passed } | ForEach-Object {
+        $name = $_.Name
+        $testresults += [pscustomobject]@{
+          Describe = $_.Describe
+          Context  = $_.Context
+          Name	 = "It $name"
+          Result   = $_.Result
+          Message  = $_.FailureMessage
+        }
+      }
+    }
+  }
+}
+#endregion Run General Tests
+
+#region Test Commands
+if ($TestFunctions)
+{
+Write-PSFMessage -Level Important -Message "Proceeding with individual tests"
+  foreach ($file in (Get-ChildItem "$PSScriptRoot\functions" -Recurse -File | Where-Object Name -like "*Tests.ps1"))
+  {
+    if ($file.Name -notlike $Include) { continue }
+    if ($file.Name -like $Exclude) { continue }
+    
+    Write-PSFMessage -Level Significant -Message "  Executing $($file.Name)"
+    $results = Invoke-Pester -Script $file.FullName -Show $Show -PassThru
+    foreach ($result in $results)
+    {
+      $totalRun += $result.TotalCount
+      $totalFailed += $result.FailedCount
+      $result.TestResult | Where-Object { -not $_.Passed } | ForEach-Object {
+        $name = $_.Name
+        $testresults += [pscustomobject]@{
+          Describe = $_.Describe
+          Context  = $_.Context
+          Name	 = "It $name"
+          Result   = $_.Result
+          Message  = $_.FailureMessage
+        }
+      }
+    }
+  }
+}
+#endregion Test Commands
+
+$testresults | Sort-Object Describe, Context, Name, Result, Message | Format-List
+
+if ($totalFailed -eq 0) { Write-PSFMessage -Level Critical -Message "All <c='em'>$totalRun</c> tests executed without a single failure!" }
+else { Write-PSFMessage -Level Critical -Message "<c='em'>$totalFailed tests</c> out of <c='sub'>$totalRun</c> tests failed!" }
+
+if ($totalFailed -gt 0)
+{
+  throw "$totalFailed / $totalRun tests failed!"
+}

--- a/src/tests/readme.md
+++ b/src/tests/readme.md
@@ -1,0 +1,31 @@
+# Description
+
+This is the folder, where all the tests go.
+
+Those are subdivided in two categories:
+
+- General
+- Function
+
+## General Tests
+
+General tests are function generic and test for general policies.
+
+These test scan answer questions such as:
+
+- Is my module following my style guides?
+- Does any of my scripts have a syntax error?
+- Do my scripts use commands I do not want them to use?
+- Do my commands follow best practices?
+- Do my commands have proper help?
+
+Basically, these allow a general module health check.
+
+These tests are already provided as part of the template.
+
+## Function Tests
+
+A healthy module should provide unit and integration tests for the commands & components it ships.
+Only then can be guaranteed, that they will actually perform as promised.
+
+However, as each such test must be specific to the function it tests, there cannot be much in the way of templates.

--- a/src/xml/puppet.dsc.Format.ps1xml
+++ b/src/xml/puppet.dsc.Format.ps1xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-16"?>
+<Configuration>
+  <ViewDefinitions>
+    <!-- Foo.Bar -->
+    <View>
+      <Name>Foo.Bar</Name>
+      <ViewSelectedBy>
+        <TypeName>Foo.Bar</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize/>
+        <TableHeaders>
+          <TableColumnHeader/>
+          <TableColumnHeader/>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Foo</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Bar</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+  </ViewDefinitions>
+</Configuration>

--- a/src/xml/puppet.dsc.Types.ps1xml
+++ b/src/xml/puppet.dsc.Types.ps1xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Types>
+  <!-- Foo.Bar -->
+  <Type>
+    <Name>Deserialized.Foo.Bar</Name>
+    <Members>
+      <MemberSet>
+        <Name>PSStandardMembers</Name>
+        <Members>
+          <NoteProperty>
+            <Name>
+              TargetTypeForDeserialization
+            </Name>
+            <Value>
+              Foo.Bar
+            </Value>
+          </NoteProperty>
+        </Members>
+      </MemberSet>
+    </Members>
+  </Type>
+  <Type>
+    <Name>Foo.Bar</Name>
+    <Members>
+      <CodeProperty IsHidden="true">
+        <Name>SerializationData</Name>
+        <GetCodeReference>
+          <TypeName>PSFramework.Serialization.SerializationTypeConverter</TypeName>
+          <MethodName>GetSerializationData</MethodName>
+        </GetCodeReference>
+      </CodeProperty>
+    </Members>
+    <TypeConverter>
+      <TypeName>PSFramework.Serialization.SerializationTypeConverter</TypeName>
+    </TypeConverter>
+  </Type>
+</Types>

--- a/src/xml/readme.md
+++ b/src/xml/readme.md
@@ -1,0 +1,43 @@
+# XML
+
+This is the folder where project XML files go, notably:
+
+- Format XML
+- Type Extension XML
+
+External help files should _not_ be placed in this folder!
+
+## Notes on Files and Naming
+
+There should be only one format file and one type extension file per project, as importing them has a notable impact on import times.
+
+- The Format XML should be named `puppet.dsc.Format.ps1xml`
+- The Type Extension XML should be named `puppet.dsc.Types.ps1xml`
+
+## Tools
+
+### New-PSMDFormatTableDefinition
+
+This function will take an input object and generate format xml for an auto-sized table.
+
+It provides a simple way to get started with formats.
+
+### Get-PSFTypeSerializationData
+
+```text
+C# Warning!
+This section is only interest if you're using C# together with PowerShell.
+```
+
+This function generates type extension XML that allows PowerShell to convert types written in C# to be written to file and restored from it without being 'Deserialized'. Also works for jobs or remoting, if both sides have the `PSFramework` module and type extension loaded.
+
+In order for a class to be eligible for this, it needs to conform to the following rules:
+
+- Have the `[Serializable]` attribute
+- Be public
+- Have an empty constructor
+- Allow all public properties/fields to be set (even if setting it doesn't do anything) without throwing an exception.
+
+```text
+non-public properties and fields will be lost in this process!
+```


### PR DESCRIPTION
This PR lays the ground work for switching to delivering our builder as a PowerShell module instead of as a script, using the PSModuleDevelopment template, `PSFModule`.

It also moves the existing public function, `Get-DscResourceTypeInformation` into the module folder structure and imports the module into the build script for use, meaning future functions can be placed into the module and then called in the builder.