### PR TITLE
(IAC-667) Ensure Get-DscResourceTypeInformation has test coverage

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -87,11 +87,9 @@ Get-ChildITem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'templates/resourc
 # build puppet types from dsc resources
 [string]$puppetTypeTemplate         = [IO.Path]::Combine($PSScriptRoot, 'templates', 'dsc_type.eps')
 [string]$puppetProviderTemplate     = [IO.Path]::Combine($PSScriptRoot, 'templates', 'dsc_provider.eps')
-[string]$dscResourcePowerShellTypes = [IO.Path]::Combine($PSScriptRoot, 'templates', 'dsc_resource_types.ps1xml')
 [string]$puppetTypeDir              = [IO.Path]::Combine($moduleDir, 'lib', 'puppet', 'type')
 [string]$puppetProviderDir          = [IO.Path]::Combine($moduleDir, 'lib', 'puppet', 'provider')
 
-Update-TypeData -PrependPath $dscResourcePowerShellTypes
 
 If (!(Get-Module -Name 'EPS' -ListAvailable)) {
   Install-Module -Name 'EPS'

--- a/src/functions/Get-DscResourceTypeInformation.ps1
+++ b/src/functions/Get-DscResourceTypeInformation.ps1
@@ -12,10 +12,10 @@ Function Get-DscResourceTypeInformation {
       The DscResourceInfo object to introspect; can be passed via the pipeline, normally retrieved
       via calling Get-DscResource.
 
-    .PARAMETER DscResourceName
+    .PARAMETER Name
       If not passing a full object, specify the name of the DSC Resource to retrieve and introspect.
 
-    .PARAMETER ModuleName
+    .PARAMETER Module
       If not passing a full object, specify the module name of the the DSC Resource to retrieve and introspect.
       Can be either a string or a hash containing the keys ModuleName and ModuleVersion.
 
@@ -71,86 +71,8 @@ Function Get-DscResourceTypeInformation {
       }
     }
     ForEach ($Resource in $DscResource) {
-      Write-Verbose "Processing DscResource: $($Resource.Name)"
-      Write-Verbose "Module Name:            $($Resource.ModuleName)"
-      Write-Verbose "Module Version:         $($Resource.Version)"
-      Write-Verbose "Implemented As:         $($Resource.ImplementedAs)"
-      Write-Verbose "Path:                   $($Resource.Path)"
-      # We have to copy the info into a custom object because the DscResourceInfo object did not want to
-      # add an array property for inserting additional information. A bit silly but it works so /shrug
-      $ResourceInformation = [PSCustomObject]@{
-        Name               = $Resource.Name.ToLowerInvariant()
-        FriendlyName       = $Resource.FriendlyName
-        ProviderName       = $Resource.provider_name
-        ResourceType       = $Resource.ResourceType
-        Module             = $Resource.Module
-        ModuleName         = $Resource.ModuleName
-        Version            = $Resource.Version
-        ImplementedAs      = $Resource.ImplementedAs
-        relative_mof_path  = $Resource.relative_mof_path
-        Properties         = $Resource.Properties
-        allowed_properties = $Resource.allowed_properties
-        ParameterInfo      = New-Object -TypeName System.Collections.ArrayList
-      }
-      # We can only parse PowerShell-implemented DSC resources for now
-      If ($Resource.ImplementedAs -eq 'PowerShell') {
-        $ParsedAst = [system.management.automation.language.parser]::ParseFile($Resource.Path, [ref]$null, [ref]$null)
-      }
-      If ($null -ne $ParsedAst) {
-        # We can curreently only retrieve parameter metadata from function and composite DSC resources, not class-based :(
-        # There are probably more elegant AST filters but this worked for now.
-        $GetFunctionAst = $ParsedAst.FindAll({$true}, $true) | Where-Object -FilterScript {$_.Name -eq 'Get-TargetResource'}
-        $SetFunctionAst = $ParsedAst.FindAll({$true}, $true) | Where-Object -FilterScript {$_.Name -eq 'Set-TargetResource'}
-        $FilterForMandatoryParameters = {
-          $MandatoryAttribute = $_.Attributes.NamedArguments | Where-Object -FilterScript {
-            $_.ArgumentName -eq 'Mandatory' -and
-            [string]$_.Argument -eq '$true'
-          }
-          $null -ne $MandatoryAttribute
-        }
-        If ($null -ne $GetFunctionAst) {
-          $MandatoryGetParameters = $GetFunctionAst.body.ParamBlock.Parameters |
-            Where-Object -FilterScript $FilterForMandatoryParameters
-        }
-        If ($null -ne $SetFunctionAst) {
-          $MandatorySetParameters = $SetFunctionAst.body.ParamBlock.Parameters |
-            Where-Object -FilterScript $FilterForMandatoryParameters
-          # We only care about searching for help info on the set as it's the closest analog
-          $HelpInfo = $SetFunctionAst.GetHelpContent().Parameters
-        }
-      }
-      # We iterate over allowed_properties to get those that will work via Invoke-DscResource
-      # Note that this will always return PSDscRunAsCredential (if run on 5x), which doesn't work in 7+
-      ForEach ($Parameter in $Resource.allowed_properties) {
-        If ($null -ne $HelpInfo) {
-          $ParameterDescription = $HelpInfo[$Parameter.Name.ToUpper()]
-          If ($null -ne $ParameterDescription) { $ParameterDescription = $ParameterDescription.Trim()}
-        } Else { $ParameterDescription = $null }
-        If ($null -ne $SetFunctionAst) {
-          $MandatorySet = ("`$$($Parameter.Name)" -in [string[]]$MandatorySetParameters.Name)
-          $DefaultValue = $SetFunctionAst.body.ParamBlock.Parameters |
-            Where-Object  -FilterScript { $_.Name -match [string]$Parameter.Name } |
-            Select-Object -ExpandProperty DefaultValue
-        } Else { $MandatorySet = $Parameter.Required }
-        If ($null -ne $GetFunctionAst) {
-          $MandatoryGet = ("`$$($Parameter.Name)" -in [string[]]$MandatoryGetParameters.Name)
-        } Else { $MandatoryGet = $Parameter.Required }
-        # We want to return all the useful info from allowed_properties PLUS
-        # the help (if any), the default set value (if any), and whether or not the param is mandatory
-        # for get or set calls (it *may* be manadatory for set but not get) - if we can't parse, default
-        # to using the Required designation from Get-DscResource, which only cares about setting.
-        $ResourceInformation.ParameterInfo.Add([pscustomobject] @{
-          Name              = $Parameter.Name.ToLowerInvariant()
-          DefaultValue      = $DefaultValue
-          Type              = $Parameter.Type
-          Help              = $ParameterDescription
-          mandatory_for_get = $MandatoryGet.ToString().ToLowerInvariant()
-          mandatory_for_set = $MandatorySet.ToString().ToLowerInvariant()
-          mof_type          = $Parameter.ShortType
-          mof_is_embedded   = $Parameter.EmbeddedInstance.ToString().ToLowerInvariant()
-        }) | Out-Null
-      }
-      $ResourceInformation
+      $Resource.ParameterInfo = Get-DscResourceParameterInfo -DscResource $Resource
+      $Resource
     }
   }
 

--- a/src/functions/Get-DscResourceTypeInformation.ps1
+++ b/src/functions/Get-DscResourceTypeInformation.ps1
@@ -64,15 +64,22 @@ Function Get-DscResourceTypeInformation {
   Process {
     # Retrieve the DSC Resource information from the system unless passed directly
     If ($null -eq $DscResource) {
-      if ($null -eq $ModuleName) {
-        $DscResource = Get-DscResource -Name $Name -ErrorAction Stop
+      if ($null -eq $Module) {
+        $DscResourceToProcess = Get-DscResource -Name $Name -ErrorAction Stop
       } else {
-        $DscResource = Get-DscResource -Name $Name -Module $Module -ErrorAction Stop
+        $DscResourceToProcess = Get-DscResource -Name $Name -Module $Module -ErrorAction Stop
       }
+    } Else {
+      $DscResourceToProcess = $DscResource
     }
-    ForEach ($Resource in $DscResource) {
-      $Resource.ParameterInfo = Get-DscResourceParameterInfo -DscResource $Resource
-      $Resource
+    ForEach ($Resource in $DscResourceToProcess) {
+      $Parameters = @{
+        MemberType = 'NoteProperty'
+        Name       = 'ParameterInfo'
+        Value      = (Get-DscResourceParameterInfo -DscResource $Resource)
+        PassThru   = $True
+      }
+      $Resource | Add-Member @Parameters
     }
   }
 

--- a/src/internal/functions/Get-DscResourceParameterInfo.ps1
+++ b/src/internal/functions/Get-DscResourceParameterInfo.ps1
@@ -1,0 +1,92 @@
+function Get-DscResourceParameterInfo {
+  <#
+  .SYNOPSIS
+    Retrieve the DSC Parameter information, if possible
+
+    .DESCRIPTION
+    Given a DSC Resource Info object, introspect on the source (if possible) to return information about
+    the resources parameters, including their help text, whether or not they are mandatory for calling the
+    resource with the Get method, and whether or not they are mandatory for calling the resource with the
+    Set method.
+
+    This information can be reliably retrieved if the DSC resource is implemented in PowerShell and is
+    not class based. Otherewise, best guesses are made about the mandatory status of the parameters via
+    the Required attribute and the help information is null.
+
+    .PARAMETER DscResource
+    A Dsc Resource Info object, as returned by Get-DscResource.
+
+  .EXAMPLE
+    Get-DscResource -Name PSRepository | Get-DscResourceParameterInfo
+  #>
+  [CmdletBinding()]
+  param (
+    [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]$DscResource
+  )
+  
+  Begin {}
+  
+  Process {
+    If ($DscResource.ImplementedAs -eq 'PowerShell') {
+      $ParsedAst = [system.management.automation.language.parser]::ParseFile($DscResource.Path, [ref]$null, [ref]$null)
+    }
+    If ($null -ne $ParsedAst) {
+      # We can curreently only retrieve parameter metadata from function and composite DSC resources, not class-based :(
+      # There are probably more elegant AST filters but this worked for now.
+      $GetFunctionAst = $ParsedAst.FindAll({$true}, $true) | Where-Object -FilterScript {$_.Name -eq 'Get-TargetResource'}
+      $SetFunctionAst = $ParsedAst.FindAll({$true}, $true) | Where-Object -FilterScript {$_.Name -eq 'Set-TargetResource'}
+      $FilterForMandatoryParameters = {
+        $MandatoryAttribute = $_.Attributes.NamedArguments | Where-Object -FilterScript {
+          $_.ArgumentName -eq 'Mandatory' -and
+          [string]$_.Argument -eq '$true'
+        }
+        $null -ne $MandatoryAttribute
+      }
+      If ($null -ne $GetFunctionAst) {
+        $MandatoryGetParameters = $GetFunctionAst.body.ParamBlock.Parameters |
+          Where-Object -FilterScript $FilterForMandatoryParameters
+      }
+      If ($null -ne $SetFunctionAst) {
+        $MandatorySetParameters = $SetFunctionAst.body.ParamBlock.Parameters |
+          Where-Object -FilterScript $FilterForMandatoryParameters
+        # We only care about searching for help info on the set as it's the closest analog
+        $HelpInfo = $SetFunctionAst.GetHelpContent().Parameters
+      }
+    }
+    # We iterate over allowed_properties to get those that will work via Invoke-DscResource
+    # Note that this will always return PSDscRunAsCredential (if run on 5x), which doesn't work in 7+
+    ForEach ($Parameter in $Resource.allowed_properties) {
+      If ($null -ne $AstInformation.HelpInfo) {
+        $ParameterDescription = $HelpInfo[$Parameter.Name.ToUpper()]
+        If ($null -ne $ParameterDescription) { $ParameterDescription = $ParameterDescription.Trim()}
+      } Else { $ParameterDescription = $null }
+      If ($null -ne $SetFunctionAst) {
+        $MandatorySet = ("`$$($Parameter.Name)" -in [string[]]$MandatorySetParameters.Name)
+        $DefaultValue = $SetFunctionAst.body.ParamBlock.Parameters |
+          Where-Object  -FilterScript { $_.Name -match [string]$Parameter.Name } |
+          Select-Object -ExpandProperty DefaultValue
+      } Else { $MandatorySet = $Parameter.Required }
+      If ($null -ne $GetFunctionAst) {
+        $MandatoryGet = ("`$$($Parameter.Name)" -in [string[]]$MandatoryGetParameters.Name)
+      } Else { $MandatoryGet = $Parameter.Required }
+      # We want to return all the useful info from allowed_properties PLUS
+      # the help (if any), the default set value (if any), and whether or not the param is mandatory
+      # for get or set calls (it *may* be manadatory for set but not get) - if we can't parse, default
+      # to using the Required designation from Get-DscResource, which only cares about setting.
+      [pscustomobject] @{
+        # Downcase the name for the sake of Puppet expectations
+        Name              = $Parameter.Name.ToLowerInvariant()
+        DefaultValue      = $DefaultValue
+        Type              = $Parameter.Type
+        Help              = $ParameterDescription
+        # Turn a boolean into a string and downcase for Puppet language
+        mandatory_for_get = $MandatoryGet.ToString().ToLowerInvariant()
+        mandatory_for_set = $MandatorySet.ToString().ToLowerInvariant()
+        mof_is_embedded   = $Parameter.EmbeddedInstance.ToString().ToLowerInvariant()
+        mof_type          = $Parameter.ShortType
+      }
+    }
+  }
+
+  End {}
+}

--- a/src/internal/functions/Get-DscResourceParameterInfo.ps1
+++ b/src/internal/functions/Get-DscResourceParameterInfo.ps1
@@ -57,8 +57,8 @@ function Get-DscResourceParameterInfo {
     }
     # We iterate over allowed_properties to get those that will work via Invoke-DscResource
     # Note that this will always return PSDscRunAsCredential (if run on 5x), which doesn't work in 7+
-    ForEach ($Parameter in $Resource.allowed_properties) {
-      If ($null -ne $AstInformation.HelpInfo) {
+    ForEach ($Parameter in $DscResource.allowed_properties) {
+      If ($null -ne $HelpInfo) {
         $ParameterDescription = $HelpInfo[$Parameter.Name.ToUpper()]
         If ($null -ne $ParameterDescription) { $ParameterDescription = $ParameterDescription.Trim()}
       } Else { $ParameterDescription = $null }

--- a/src/internal/functions/Get-DscResourceParameterInfo.ps1
+++ b/src/internal/functions/Get-DscResourceParameterInfo.ps1
@@ -18,14 +18,16 @@ function Get-DscResourceParameterInfo {
 
   .EXAMPLE
     Get-DscResource -Name PSRepository | Get-DscResourceParameterInfo
+
+    Retrieve the Parameter information from the AST for the PSRepository Dsc Resource.
   #>
   [CmdletBinding()]
   param (
     [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]$DscResource
   )
-  
+
   Begin {}
-  
+
   Process {
     If ($DscResource.ImplementedAs -eq 'PowerShell') {
       $ParsedAst = [system.management.automation.language.parser]::ParseFile($DscResource.Path, [ref]$null, [ref]$null)

--- a/src/puppet.dsc.psd1
+++ b/src/puppet.dsc.psd1
@@ -34,7 +34,7 @@
   # RequiredAssemblies = @('bin\puppet.dsc.dll')
   
   # Type files (.ps1xml) to be loaded when importing this module
-  # TypesToProcess = @('xml\puppet.dsc.Types.ps1xml')
+  TypesToProcess = @('xml/puppet.dsc.Types.ps1xml')
   
   # Format files (.ps1xml) to be loaded when importing this module
   # FormatsToProcess = @('xml\puppet.dsc.Format.ps1xml')

--- a/src/puppet.dsc.psd1
+++ b/src/puppet.dsc.psd1
@@ -27,6 +27,7 @@
   # this module
   RequiredModules = @(
     @{ ModuleName='PSFramework'; ModuleVersion='1.1.59' }
+    'PSDesiredStateConfiguration'
   )
   
   # Assemblies that must be loaded prior to importing this module

--- a/src/tests/functions/Get-DscResourceParameterInfo.Tests.ps1
+++ b/src/tests/functions/Get-DscResourceParameterInfo.Tests.ps1
@@ -1,0 +1,44 @@
+Describe 'Parameter Information Retrieval' {
+  InModuleScope puppet.dsc {
+    Context 'When the AST can be parsed for functions' {
+      It 'returns the full set of expected parameter info if the resource can be parsed fully' {
+        # We cannot effectively mock out the underlying object, so we need to retrieve a
+        # well-known DSC resource at a specific version
+        $FullyParseableResource = Get-DscResource -Name Archive -Module @{
+          ModuleName    = 'PSDscResources'
+          ModuleVersion = '2.12.0.0'
+        }
+        $ParameterToInspect = Get-DscResourceParameterInfo -DscResource $FullyParseableResource |
+          Select-Object -Last 1
+        $ParameterToInspect.Name | Should -BeExactly 'validate'
+        $ParameterToInspect.DefaultValue | Should -BeExactly '$false'
+        $ParameterToInspect.Type | Should -BeExactly '"Optional[Boolean]"'
+        $ParameterToInspect.Help | Should -MatchExactly '^Specifies whether or not'
+        $ParameterToInspect.mandatory_for_get | Should -BeExactly 'false'
+        $ParameterToInspect.mandatory_for_set | Should -BeExactly 'false'
+        $ParameterToInspect.mof_is_embedded | Should -BeExactly 'false'
+        $ParameterToInspect.mof_type | Should -BeExactly 'bool'
+      }
+    }
+    Context 'When the AST cannot be parsed for functions' {
+      # We cannot effectively mock out the underlying object, so we need to retrieve a
+      # well-known DSC resource at a specific version
+      $BinaryResource = Get-DscResource -Name File
+      
+      It 'returns only the set of values retrievable from the DscResourceInfo object' {
+        $ParameterToInspect = Get-DscResourceParameterInfo -DscResource $BinaryResource |
+          Select-Object -First 1
+        $ParameterToInspect.Name | Should -BeExactly 'destinationpath'
+        # The default value for a parameter can only be discovered via the AST
+        $ParameterToInspect.DefaultValue | Should -BeNullOrEmpty
+        $ParameterToInspect.Type | Should -BeExactly "'String'"
+        # The help info for a parameter can only be discovered via the AST
+        $ParameterToInspect.Help | Should -BeNullOrEmpty
+        $ParameterToInspect.mandatory_for_get | Should -BeExactly 'true'
+        $ParameterToInspect.mandatory_for_set | Should -BeExactly 'true'
+        $ParameterToInspect.mof_is_embedded | Should -BeExactly 'false'
+        $ParameterToInspect.mof_type | Should -BeExactly 'string'
+      }
+    }
+  }
+}

--- a/src/tests/functions/Get-DscResourceTypeInformation.Tests.ps1
+++ b/src/tests/functions/Get-DscResourceTypeInformation.Tests.ps1
@@ -1,0 +1,99 @@
+Describe "Parameter Handling" {
+  InModuleScope puppet.dsc {
+    Context "When Passed a DscResourceInfo object" {
+      Mock Get-DscResource {}
+      Mock Get-DscResourceParameterInfo { return $DscResource.Name }
+      $DscResources = [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo[]]@(
+        @{Name = 'foo'}
+        @{Name = 'bar'}
+      )
+      
+      $Result = $DscResources | Get-DscResourceTypeInformation
+      
+      It "processes once for each object in the pipeline" {
+        Assert-MockCalled Get-DscResourceParameterInfo -Times 2
+        $Result[0].ParameterInfo | Should -be $Result[0].Name
+      }
+
+      It "never calls Get-DscResource" {
+        Assert-MockCalled Get-DscResource -Times 0
+      }
+    }
+
+    Context "When specifying properties" {
+      Context "by name only" {
+        Mock Get-DscResourceParameterInfo { return $DscResource.Name }
+        Mock Get-DscResource {
+          ForEach-Object -InputObject $Name -Process {
+            [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+              Name = $Name
+            }
+          }
+        }
+
+        It 'calls Get-DscResource once' {
+          $Result = Get-DscResourceTypeInformation -Name foo, bar, baz
+          $Result[0].ParameterInfo | Should -Be $Result[0].Name
+          Assert-MockCalled Get-DscResource -Times 1
+        }
+      }
+
+      Context "by name and module" {
+        Mock Get-DscResourceParameterInfo { return $DscResource.Name }
+        Mock Get-DscResource {
+          [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+            Name = $Name
+          }
+        }
+        Mock Get-DscResource {
+          [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+            Name = $Module
+          }
+        }  -ParameterFilter { $null -ne $Module }
+
+        $Result = Get-DscResourceTypeInformation -Name bar -Module foo
+
+        It 'Only searches by module if specified' {
+          $Result.ParameterInfo | Should -Be 'foo'
+          Assert-MockCalled Get-DscResource -Times 1
+          Assert-MockCalled Get-DscResource -Times 1 -ParameterFilter {
+            $Module -eq 'foo'
+          }
+        }
+      }
+
+      Context 'via the pipeline' {
+        Mock Get-DscResourceParameterInfo { return $DscResource.Name }
+        Mock Get-DscResource {
+          [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+            Name = $Name
+          }
+        }  -ParameterFilter { $Name -eq 'foo' }
+        Mock Get-DscResource {
+          [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+            Name = $Module
+          }
+        } -ParameterFilter { $Module -eq 'baz' }
+
+        # Objects with name and module properties to pass to the function
+        $NameOnly = [PSCustomObject]@{ Name = 'foo' }
+        $NameAndModule = [PSCustomObject]@{
+          Name = 'bar'
+          Module = 'baz'
+        }
+        $Results = $NameOnly,$NameAndModule | Get-DscResourceTypeInformation
+
+        It 'handles pipeline input by property name' {
+          $Results.Count | Should -Be 2
+          $Results[0].Name | Should -Be 'foo'
+          $Results[1].Name | Should -Be 'baz'
+        }
+
+        It 'processes once for each resource found' {
+          Assert-MockCalled Get-DscResource -Times 2
+          Assert-MockCalled Get-DscResourceParameterInfo -Times 2
+        }
+      }
+    }
+  }
+}

--- a/src/tests/pester.ps1
+++ b/src/tests/pester.ps1
@@ -16,10 +16,7 @@ Write-PSFMessage -Level Important -Message "Starting Tests"
 Write-PSFMessage -Level Important -Message "Importing Module"
 
 Remove-Module puppet.dsc -ErrorAction Ignore
-Import-Module "$PSScriptRoot\..\puppet.dsc.psd1"
-Import-Module "$PSScriptRoot\..\puppet.dsc.psm1" -Force
-
-
+Import-Module "$PSScriptRoot\..\puppet.dsc.psd1" -Force
 
 $totalFailed = 0
 $totalRun = 0

--- a/src/xml/puppet.dsc.Types.ps1xml
+++ b/src/xml/puppet.dsc.Types.ps1xml
@@ -1,37 +1,125 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Types>
-  <!-- Foo.Bar -->
   <Type>
-    <Name>Deserialized.Foo.Bar</Name>
+    <Name>Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo</Name>
     <Members>
-      <MemberSet>
-        <Name>PSStandardMembers</Name>
-        <Members>
-          <NoteProperty>
-            <Name>
-              TargetTypeForDeserialization
-            </Name>
-            <Value>
-              Foo.Bar
-            </Value>
-          </NoteProperty>
-        </Members>
-      </MemberSet>
+      <ScriptProperty>
+        <Name>provider_name</Name>
+        <GetScriptBlock>
+          [string]$first = $this.name.Substring(0,1)
+          $first.ToUpperInvariant() + $this.name.ToLowerInvariant().Substring(1)
+        </GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>relative_mof_path</Name>
+        <GetScriptBlock>
+          if($this.Path.Contains('WINDOWS\system32\WindowsPowershell\v1.0\Modules')){
+            (Split-Path $this.Path -NoQualifier).Replace('\WINDOWS\system32\WindowsPowershell\v1.0\Modules\', '')
+          }else{
+            $this.Path.Replace('import/dsc_resources/','')
+          }
+        </GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>allowed_properties</Name>
+        <GetScriptBlock>
+          $this.properties | ? { $_.name -notmatch '(dependson|waitfor.*)' }
+        </GetScriptBlock>
+      </ScriptProperty>
     </Members>
   </Type>
   <Type>
-    <Name>Foo.Bar</Name>
+    <Name>Microsoft.PowerShell.DesiredStateConfiguration.DscResourcePropertyInfo</Name>
     <Members>
-      <CodeProperty IsHidden="true">
-        <Name>SerializationData</Name>
-        <GetCodeReference>
-          <TypeName>PSFramework.Serialization.SerializationTypeConverter</TypeName>
-          <MethodName>GetSerializationData</MethodName>
-        </GetCodeReference>
-      </CodeProperty>
+      <ScriptProperty>
+        <Name>description</Name>
+        <GetScriptBlock>
+          "TODO!!!"
+        </GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>ShortType</Name>
+        <GetScriptBlock>
+          $text = $this.PropertyType.TrimStart('[')
+          if($text.EndsWith(']]')){
+            $text = $text.Replace(']]',']')
+          }else{
+            $text = $text.TrimEnd(']')
+          }
+          $text
+        </GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>Type</Name>
+        <GetScriptBlock>
+          if($this.values){
+            $typeText = "Enum[$( ($this.Values | % { "'$($_.ToLowerInvariant())'" }) -join `", `" )]"
+          }else{
+            if($this.embeddedinstance){
+              $typeText = 'String'
+            }else{
+              $typeText = switch ($this.PropertyType.TrimStart('[').TrimEnd(']')){
+                'Bool' { 'Boolean';break; }
+                'String' { 'String';break; }
+                default { $_; }
+              }
+            }
+          }
+
+          if($this.array){
+            $typeText = "Array[$($typeText)]"
+          }
+
+          if($this.credential){
+            $typeText = "Struct[{ user => String[1], password => String[1] }]"
+          }
+
+          switch($this.IsMandatory){
+            $true {
+              "'$($typeText)'"
+            }
+            $false{
+              "`"Optional[$($typeText)]`""
+            }
+          }
+        </GetScriptBlock>
+      </ScriptProperty>
+      <AliasProperty>
+        <Name>required</Name>
+        <ReferencedMemberName>IsMandatory</ReferencedMemberName>
+      </AliasProperty>
+      <ScriptProperty>
+        <Name>embeddedinstance</Name>
+        <GetScriptBlock>
+$EmbeddedInstances = @{
+  "Hashtable"         = "MSFT_KeyValuePair";
+  "PSCredential"      = "MSFT_Credential";
+  "Hashtable[]"       = "MSFT_KeyValuePair";
+  "PSCredential[]"    = "MSFT_Credential";
+  "HashtableArray"    = "MSFT_KeyValuePair";
+  "PSCredentialArray" = "MSFT_Credential";
+}
+$basetypes = @(
+"[Uint8","[Uint16]","[Uint32]","[Uint64]",`
+"[Sint8]","[Sint16]","[Sint32]","[Sint64]",`
+"[Real32]","[Real64]","[Char16]","[String]",`
+"[bool]","[Boolean]","[DateTime]","[Hashtable]",`
+"[PSCredential]",`
+"[Uint8[]]","[Uint16[]]","[Uint32[]]","[Uint64[]]",`
+"[Sint8[]]","[Sint16[]]","[Sint32[]]","[Sint64[]]",`
+"[Real32[]]","[Real64[]]","[Char16[]]","[String[]]",`
+"[Boolean[]]","[DateTime[]]","[Hashtable[]]",`
+"[PSCredential[]]",`
+"Microsoft.Management.Infrastructure.CimInstance",`
+"Microsoft.Management.Infrastructure.CimInstance[]"
+        )
+        if($basetypes -contains $this.PropertyType){
+          return $false
+        }else{
+          return $true
+        }
+        </GetScriptBlock>
+      </ScriptProperty>
     </Members>
-    <TypeConverter>
-      <TypeName>PSFramework.Serialization.SerializationTypeConverter</TypeName>
-    </TypeConverter>
   </Type>
 </Types>


### PR DESCRIPTION
This PR is an example of decomposing a public function for testability and includes unit tests for the public function, `Get-DscResourceTypeInformation` and the private function it depends upon, `Get-DscResourceParameterInfo`.