### PR TITLE
(MAINT) Add full build proc to CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ install:
 build: off
 test_script:
   - ps: '& .\src\tests\pester.ps1'
+  - ps: '& .\build.ps1'
 notifications:
   - provider: Email
     on_build_success: false

--- a/extras/install.ps1
+++ b/extras/install.ps1
@@ -17,6 +17,7 @@ $PowerShellModules = @(
   @{ Name = 'PSFramework' }
   @{ Name = 'PSModuleDevelopment' }
   @{ Name = 'PowerShellGet' }
+  @{ Name = 'powershell-yaml' }
   @{ Name = 'PSScriptAnalyzer' }
   @{ Name = 'PSDepend' }
   @{ Name = 'xPSDesiredStateConfiguration' }


### PR DESCRIPTION
This commit ensures that the build script will attempt to run after
the pester CI tests so we get fast feedback in the form of a loose
acceptance test; this is not a replacement for proper acceptance
testing, just a quick bandaid.