### PR TITLE
(maint) Pin PowerShellGet module to ver 2.2.3

### DIFF
--- a/extras/install.ps1
+++ b/extras/install.ps1
@@ -16,7 +16,7 @@ choco install $ChocolateyPackages -y --no-progress
 $PowerShellModules = @(
   @{ Name = 'PSFramework' }
   @{ Name = 'PSModuleDevelopment' }
-  @{ Name = 'PowerShellGet' }
+  @{ Name = 'PowerShellGet' ; RequiredVersion = '2.2.3' }
   @{ Name = 'powershell-yaml' }
   @{ Name = 'PSScriptAnalyzer' }
   @{ Name = 'PSDepend' }


### PR DESCRIPTION
# Description
Encountered issues installing the latest version (2.2.4) of the PowerShellGet module:
```powershell
PackageManagement\Install-Package : The module 'PowerShellGet' cannot be installed because the catalog signature in               
'PowerShellGet.cat' does not match the hash generated from the module.                                                            
At C:\Program Files\WindowsPowerShell\Modules\PowerShellGet\1.0.0.1\PSModule.psm1:1809 char:21                                    
+ ...          $null = PackageManagement\Install-Package @PSBoundParameters                                                       
+                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                       
    + CategoryInfo          : InvalidOperation: (Microsoft.Power....InstallPackage:InstallPackage) [Install-Package], Exception   
    + FullyQualifiedErrorId : InvalidCatalogSignature,ValidateAndGet-AuthenticodeSignature,Microsoft.PowerShell.PackageManagemen  
   t.Cmdlets.InstallPackage                                                                                                                                                      
```
Appears as though the latest version of the module has not been signed correctly. This should only act as a temporary workaround for now.
# Tests
- [x] Built VM from Vagrantfile with changes to `extras/install.ps1`