### PR TITLE
(IAC-710) Improve DSC Resource Type Handling

### DIFF
--- a/src/internal/functions/Get-PuppetDataType.ps1
+++ b/src/internal/functions/Get-PuppetDataType.ps1
@@ -13,7 +13,7 @@ Function Get-PuppetDataType {
       The DscResourcePropertyInfo object which represents a single property for a given DSC resource.
     .EXAMPLE
       Get-PuppetDataTYpe -DscResourceProperty $DscResource.Properties[0]
-      
+
       This will return a string representing the Puppet Data type that most closely equates to the
       PowerShell data type that this Property has.
   #>
@@ -58,7 +58,7 @@ Function Get-PuppetDataType {
                               'String' { 'String'  }
                               # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types
                               'byte'   { 'Integer[0, 255]' }
-                              'Uint16' { 'Integer[0,65535]' }
+                              'Uint16' { 'Integer[0, 65535]' }
                               'Uint32' { 'Integer[0, 4294967295]' }
                               'Uint64' { 'Integer[0, 18446744073709551615]' }
                               'sybte'  { 'Integer[-128, 127]' }

--- a/src/internal/functions/Get-PuppetDataType.ps1
+++ b/src/internal/functions/Get-PuppetDataType.ps1
@@ -1,0 +1,98 @@
+Function Get-PuppetDataType {
+  <#
+    .SYNOPSIS
+      Get the representation of a DSC Resource Property Type as a Puppet Resource API Data Type
+    .DESCRIPTION
+      This function provides a way of generating strongly typed Puppet Resource API attributes by
+      introspecting a DSC Resource's properties to provide as much useful feedback to manifest
+      authors at manifest-write time and catalog-compilation.
+
+      It cannot currently discover the proper structure for most embedded instances, though the
+      embedded instance schema for PSCredentials *has* been included.
+    .PARAMETER DscResourceProperty
+      The DscResourcePropertyInfo object which represents a single property for a given DSC resource.
+    .EXAMPLE
+      Get-PuppetDataTYpe -DscResourceProperty $DscResource.Properties[0]
+      
+      This will return a string representing the Puppet Data type that most closely equates to the
+      PowerShell data type that this Property has.
+  #>
+  [cmdletbinding()]
+  [OutputType([String])]
+  Param(
+    # We cannot strongly type this *and* have useful unit tests as the type
+    # has read-only values and cannot be created properly nor updated. For
+    # other commands we could just grab real examples but for processing a
+    # ton of data types, that's just not feasible. It *should* be:
+    # Microsoft.PowerShell.DesiredStateConfiguration.DscResourcePropertyInfo
+    [ValidateNotNullOrEmpty()]
+    $DscResourceProperty
+  )
+  # https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger?view=netframework-4.8
+  # https://docs.microsoft.com/en-us/dotnet/api/system.numerics.complex?view=netframework-4.8 - Can we represent a complex number in Puppet? Do we want to?
+  # https://docs.microsoft.com/en-us/dotnet/api/system.intptr?view=netframework-4.8
+  $OtherIntegers = @(
+    'bigint'
+    'IntPtr'
+    'UIntPtr'
+  )
+  # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types
+  $Floats = @(
+    'single'
+    'double'
+    'decimal'
+  )
+  If (![String]::IsNullOrEmpty($DscResourceProperty.Values)){
+    # Enums are handles specially
+    $InnerText = $DscResourceProperty.Values | ForEach-Object -Process {"'$($_.ToLowerInvariant())'"}
+    $PuppetDataTypeText = "Enum[$($InnerText -join ', ')]"
+  } Else {
+    If (Test-EmbeddedInstance -PropertyType $DscResourceProperty.PropertyType){
+      # TODO: We SHOULD be able to walk our way to the nested data structure for these Hashes
+      $PuppetDataTypeText = 'Hash'
+    } Else {
+      # Strip the brackets away for easier comparison; arrays are handled later anyway
+      $DataTypeName = $DscResourceProperty.PropertyType -replace '(\[|\])', $null
+      $PuppetDataTypeText = switch ($DataTypeName){
+                              {$_ -in 'Bool', 'Boolean' }  { 'Boolean' }
+                              'String' { 'String'  }
+                              # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types
+                              'byte'   { 'Integer[0, 255]' }
+                              'Uint16' { 'Integer[0,65535]' }
+                              'Uint32' { 'Integer[0, 4294967295]' }
+                              'Uint64' { 'Integer[0, 18446744073709551615]' }
+                              'sybte'  { 'Integer[-128, 127]' }
+                              'int16' { 'Integer[-32768, 32767]' }
+                              {$_ -in 'int', 'int32'}  { 'Integer[-2147483648, 2147483647]' }
+                              'int64' { 'Integer[-9223372036854775808, 9223372036854775807]' }
+                              { $_ -in $OtherIntegers } { 'Integer' }
+                              { $_ -in $Floats } { 'Float' }
+                              'PSCredential' { 'Struct[{ user => String[1], password => String[1] }]' }
+                              # Can we mandate that an attribute be a sensitive string? Does this even make sense?
+                              'SecureString' { 'Sensitive' }
+                              # TODO: Should this just be a string? Do we need/want to validate this?
+                              'DateTime' { 'Timestamp' }
+                              'HashTable' { 'Hash' }
+                              'Char' { 'String[1,1]' }
+                              # This is kinda gross, but this only came up once in 350+ module builds
+                              'Object' {'Any'}
+                              default  {
+                                # Better to scream loudly than write an invalid type?
+                                # Optionally include a Force param to put down `Any` as the data type?
+                                Throw "Cannot convert DSC Type '$($DscResourceProperty.PropertyType)'"
+                              }
+                            }
+    }
+  }
+
+  If ($DscResourceProperty.PropertyType -match [Regex]::Escape('[]')){
+    $PuppetDataTypeText = "Array[$($PuppetDataTypeText)]"
+  }
+
+  # Return the string formatted for being dropped directly into the type file
+  If ($True -eq $DscResourceProperty.IsMandatory) {
+    """$PuppetDataTypeText"""
+  } Else {
+    """Optional[$($PuppetDataTypeText)]"""
+  }
+}

--- a/src/internal/functions/Get-ShortType.ps1
+++ b/src/internal/functions/Get-ShortType.ps1
@@ -9,7 +9,7 @@ Function Get-ShortType {
       THe property type of a DSC resource property
     .EXAMPLE
       Get-ShortType -PropertyType $DscResource.Properties[0].PropertyType
-      
+
       This will return a string representing the property type stripped of its outer brackets
   #>
   [cmdletbinding()]
@@ -17,11 +17,11 @@ Function Get-ShortType {
   Param (
     [string]$PropertyType
   )
-  $ShortType = $PropertyType.TrimStart('[')
-  $ShortType = If ($ShortType.EndsWith(']]')) {
-                 $ShortType.Replace(']]',']')
-               } Else {
-                 $ShortType.TrimEnd(']')
-               }
+  if ($PropertyType.StartsWith('[') -and $PropertyType.EndsWith(']')) {
+    $ShortType = $PropertyType.Substring(1, $PropertyType.Length - 2)
+  }
+  else {
+    $ShortType = $PropertyType
+  }
   $ShortType
 }

--- a/src/internal/functions/Get-ShortType.ps1
+++ b/src/internal/functions/Get-ShortType.ps1
@@ -1,0 +1,27 @@
+Function Get-ShortType {
+  <#
+    .SYNOPSIS
+      Strip a type of it's brackets
+    .DESCRIPTION
+      Strip a PowerShell type of the brackets, turning [string] and [string[]] into string and string[]
+      This makes inserting the type back into PowerShell a little easier.
+    .PARAMETER PropertyType
+      THe property type of a DSC resource property
+    .EXAMPLE
+      Get-ShortType -PropertyType $DscResource.Properties[0].PropertyType
+      
+      This will return a string representing the property type stripped of its outer brackets
+  #>
+  [cmdletbinding()]
+  [OutputType([String])]
+  Param (
+    [string]$PropertyType
+  )
+  $ShortType = $PropertyType.TrimStart('[')
+  $ShortType = If ($ShortType.EndsWith(']]')) {
+                 $ShortType.Replace(']]',']')
+               } Else {
+                 $ShortType.TrimEnd(']')
+               }
+  $ShortType
+}

--- a/src/internal/functions/Get-TypeContent.ps1
+++ b/src/internal/functions/Get-TypeContent.ps1
@@ -31,17 +31,22 @@ function Get-TypeContent {
       If($Null -eq $Resource.ParameterInfo) {
         $Resource = Get-DscResourceTypeInformation -DscResource $Resource
       }
+      If ($Null -eq $Resource.FriendlyName) {
+        $FriendlyName = $Resource.Name
+      } Else {
+        $FriendlyName = $Resource.FriendlyName
+      }
       New-Object -TypeName System.String @"
 require 'puppet/resource_api'
 
 Puppet::ResourceApi.register_type(
   name: 'dsc_$($Resource.Name.ToLowerInvariant())',
-  dscmeta_resource_friendly_name: '$($Resource.FriendlyName)',
+  dscmeta_resource_friendly_name: '$FriendlyName',
   dscmeta_resource_name: '$($Resource.ResourceType)',
   dscmeta_module_name: '$($Resource.ModuleName)',
   dscmeta_module_version: '$($Resource.Version)',
   docs: %q{
-    The DSC $($Resource.FriendlyName) resource type.
+    The DSC $FriendlyName resource type.
     Automatically generated from version $($Resource.Version)
   },
   features: ['simple_get_filter'],

--- a/src/internal/functions/Test-EmbeddedInstance.ps1
+++ b/src/internal/functions/Test-EmbeddedInstance.ps1
@@ -1,0 +1,56 @@
+Function Test-EmbeddedInstance {
+  <#
+    .SYNOPSIS
+      Return whether or not a parameter is an embedded instance
+    .DESCRIPTION
+      Some DSC resources have data types which map to embedded CIM instances, which are something
+      like structured hashes. Unfortunately, we cannot know every possible embedded instance type
+      and there's no canonical way to check a DSC resource property for whether the property type
+      is itself an embedded instance, so our best proxy is to list well-known types.
+
+      THe list below was compiled on 2020-04-20 by building every single module with DSC resources
+      on the PowerShell gallery and covering the data types used in those modules which were not
+      embedded instances. This is not the full list of valid data types, but it will hopefully be
+      sufficient for our purposes and can easily be updated.
+    .PARAMETER PropertyType
+      THe property type of a DSC resource property
+    .EXAMPLE
+      Test-EmbeddedInstance -PropertyType $DscResource.Properties[0].PropertyType
+      
+      This will return `$True` if the property is an embedded instance and `$False` otherwise.
+  #>
+  [cmdletbinding()]
+  [OutputType([Boolean])]
+  Param(
+    [string]$PropertyType
+  )
+  # Check if included in Base Types
+  @(
+    'Bool'
+    'Boolean'
+    'Byte'
+    'Char'
+    'Char16'
+    'DateTime'
+    'Decimal'
+    'Double'
+    'Float'
+    'Hashtable'
+    'Int'
+    'Int16'
+    'Int32'
+    'Int64'
+    'Microsoft.Management.Infrastructure.CimInstance'
+    'Object'
+    'PSCredential'
+    'Real32'
+    'Real64'
+    'SByte'
+    'SecureString'
+    'Single'
+    'String'
+    'Uint16'
+    'Uint32'
+    'Uint64'
+  ) -NotContains ($PropertyType -replace '(\[|\])', $null)
+}

--- a/src/puppet.dsc.psd1
+++ b/src/puppet.dsc.psd1
@@ -34,7 +34,7 @@
   # RequiredAssemblies = @('bin\puppet.dsc.dll')
 
   # Type files (.ps1xml) to be loaded when importing this module
-  TypesToProcess = @('xml/puppet.dsc.Types.ps1xml')
+  # TypesToProcess = @('xml/puppet.dsc.Types.ps1xml')
 
   # Format files (.ps1xml) to be loaded when importing this module
   # FormatsToProcess = @('xml\puppet.dsc.Format.ps1xml')

--- a/src/tests/functions/Get-DscResourceParameterInfo.Tests.ps1
+++ b/src/tests/functions/Get-DscResourceParameterInfo.Tests.ps1
@@ -1,4 +1,4 @@
-Describe 'Parameter Information Retrieval' {
+Describe 'Get-DscResourceParameterInfo' {
   InModuleScope puppet.dsc {
     Context 'When the AST can be parsed for functions' {
       It 'returns the full set of expected parameter info if the resource can be parsed fully' {

--- a/src/tests/functions/Get-EmbeddedInstance.Tests.ps1
+++ b/src/tests/functions/Get-EmbeddedInstance.Tests.ps1
@@ -1,0 +1,10 @@
+Describe 'Get-EmbeddedInstance' {
+  InModuleScope puppet.dsc {
+    Context 'Basic functionality' {
+      It "Distinguishes between known and unkowable datatype" {
+        Get-ShortType -PropertyType '[string]' | Should -BeExactly 'string'
+        Get-ShortType -PropertyType '[string[]]' | Should -BeExactly 'string[]'
+      }
+    }
+  }
+}

--- a/src/tests/functions/Get-PuppetDataType.Tests.ps1
+++ b/src/tests/functions/Get-PuppetDataType.Tests.ps1
@@ -1,0 +1,44 @@
+Describe 'Get-PuppetDataType' {
+  InModuleScope puppet.dsc {
+    Context 'Basic functionality' {
+      Function New-DscParameter {
+        Param (
+          [string]$Name         = 'foo',
+          [string]$PropertyType ='[string]',
+          [string[]]$Values     = @(),
+          [switch]$IsMandatory
+        )
+        [pscustomobject]@{
+          Name         = $Name
+          PropertyType = $PropertyType
+          IsMandatory  = $IsMandatory
+          Values       = $Values
+        }
+      }
+      It 'Distinguishes between optional and mandatory parameters' {
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter) | Should -BeExactly """Optional[String]"""
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -IsMandatory) | Should -BeExactly """String"""
+      }
+      It 'Handles arrays' {
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType '[string[]]') | Should -BeExactly """Optional[Array[String]]"""
+      }
+      It 'Handles embedded instances' {
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType 'foo') | Should -BeExactly """Optional[Hash]"""
+      }
+      It 'Handles Enums' {
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -Values @('Foo', 'Bar', 'Baz')) | Should -BeExactly """Optional[Enum['foo', 'bar', 'baz']]"""
+      }
+      It 'Handles well-known types' {
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType '[Bool]') | Should -BeExactly """Optional[Boolean]"""
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType '[Byte]') | Should -BeExactly """Optional[Integer[0, 255]]"""
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType '[int]') | Should -BeExactly """Optional[Integer[-2147483648, 2147483647]]"""
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType '[PSCredential]') | Should -BeExactly """Optional[Struct[{ user => String[1], password => String[1] }]]"""
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType '[SecureString]') | Should -BeExactly """Optional[Sensitive]"""
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType '[DateTime]') | Should -BeExactly """Optional[Timestamp]"""
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType '[HashTable]') | Should -BeExactly """Optional[Hash]"""
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType '[Char]') | Should -BeExactly """Optional[String[1,1]]"""
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType '[Object]') | Should -BeExactly """Optional[Any]"""
+      }
+    }
+  }
+}

--- a/src/tests/functions/Get-ShortType.Tests.ps1
+++ b/src/tests/functions/Get-ShortType.Tests.ps1
@@ -1,0 +1,10 @@
+Describe 'Get-ShortType' {
+  InModuleScope puppet.dsc {
+    Context 'Basic functionality' {
+      It 'Returns data types stripped of their outer brackets' {
+        Get-ShortType -PropertyType '[string]' | Should -BeExactly 'string'
+        Get-ShortType -PropertyType '[string[]]' | Should -BeExactly 'string[]'
+      }
+    }
+  }
+}

--- a/src/tests/functions/Get-ShortType.Tests.ps1
+++ b/src/tests/functions/Get-ShortType.Tests.ps1
@@ -4,6 +4,7 @@ Describe 'Get-ShortType' {
       It 'Returns data types stripped of their outer brackets' {
         Get-ShortType -PropertyType '[string]' | Should -BeExactly 'string'
         Get-ShortType -PropertyType '[string[]]' | Should -BeExactly 'string[]'
+        Get-ShortType -PropertyType '[[string[]]]' | Should -BeExactly '[string[]]'
       }
     }
   }


### PR DESCRIPTION
Prior to this commit the module relied on the `Types.ps1xml` file to munge and alias DSC Resource property information to make processing easier in other functions. This was useful but at the cost of being very hard to reason about, review, update, and also impossible to usefully test with the given tools.

This commit removes our reliance on the types file entirely, moving the relevant functionality into private functions and updating the logic elsewhere to be more transparent.

It creates the following private functions:

- `Test-EmbeddedInstance`, which does a best-guess at whether or not a particular PowerShell data type represents an embedded cim instance or not. As of the time of this commit, no PowerShell modules were found with data types not covered by this function which were not actual embedded instances.
- `Get-ShortType`, which strips a DSC Resource Property PropertyType of the outer brackets, making it easier to re-insert later.
- `Get-PuppetDataType`, which does a best-effort match of PowerShell data types to Puppet data types. Unfortunately, we have not been successful in finding a programmatic way to parse all of the embedded instances discovered on the gallery. We have a potential option which may help us discover embedded instance structures for class-based resources, but not mof-based.

  Note that although we cannot build the struct for *every* embedded instance type we **have** manually added the struct for PSCredential objects as these are extremely common.

  This also fixes some of the data types which were not properly parsed by the Types.ps1xml file, ensuring that the data types are actually mapped instead of just writing PowerShell data types in the Puppet Resource API type file.

There remains some room for improvement, particularly around discovering reference documentation and handling embedded instances.