### PR TITLE
(IAC-707) Add Update-PuppetModuleReadme, Get-PuppetizedName

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -30,9 +30,9 @@ param(
   $PowerShellModuleVersion
 )
 
-If ($null -eq $PuppetModuleName) { $PuppetModuleName = $PowerShellModuleName.tolower() }
-
 Import-Module "$PSScriptRoot/src/puppet.dsc.psd1" -Force
+
+If ($null -eq $PuppetModuleName) { $PuppetModuleName = Get-PuppetizedModuleName -Name $PowerShellModuleName }
 
 $importDir   = Join-Path $PSScriptRoot 'import'
 $moduleDir   = Join-Path $importDir $PuppetModuleName
@@ -53,6 +53,14 @@ Update-PuppetModuleMetadata @MetadataParameters
 
 # Update the Puppet module test fixtures
 Update-PuppetModuleFixture -PuppetModuleFolderPath $moduleDir
+
+$ReadmeParameters = @{
+  PuppetModuleFolderPath       = $moduleDir
+  PowerShellModuleManifestPath = (Resolve-Path "$downloadedDscResources/$PowerShellModuleName/$PowerShellModuleName.psd1")
+  PowerShellModuleName         = $PowerShellModuleName
+  PuppetModuleName             = $PuppetModuleName
+}
+Update-PuppetModuleReadme @ReadmeParameters
 
 # build puppet types from dsc resources
 [string]$puppetTypeDir              = [IO.Path]::Combine($moduleDir, 'lib', 'puppet', 'type')

--- a/src/functions/Get-PuppetizedModuleName.ps1
+++ b/src/functions/Get-PuppetizedModuleName.ps1
@@ -1,0 +1,37 @@
+function Get-PuppetizedModuleName {
+  <#
+  .SYNOPSIS
+    Get a valid puppet module name from a PowerShell Module name
+  .DESCRIPTION
+    Get a valid puppet module name from a PowerShell Module name
+  .PARAMETER Name
+    The name of the PowerShell module you want to puppetize
+  .EXAMPLE
+    Get-PuppetizedModuleName -Name Azure.Something.Or.Other
+
+    This will return 'azure_something_or_other', which is a valid
+    Puppet module name.
+  #>
+  [cmdletbinding()]
+  [OutputType([String])]
+  param (
+    [string]$Name
+  )
+
+  Begin {}
+
+  Process {
+    # Puppet module names must be lowercase:
+    $PuppetizedName = $Name.ToLowerInvariant()
+    # Puppet module names may only include lowercase letters, digits, and underscores
+    $PuppetizedName = $PuppetizedName -replace '[^a-z0-9_]', '_'
+    If ($PuppetizedName -match '^\d') {
+      # This is a... not good compromise, but it works
+      "a$PuppetizedName"
+    } Else {
+      $PuppetizedName
+    }
+  }
+
+  End {}
+}

--- a/src/functions/Update-PuppetModuleReadme.ps1
+++ b/src/functions/Update-PuppetModuleReadme.ps1
@@ -1,0 +1,62 @@
+function Update-PuppetModuleReadme {
+  <#
+    .SYNOPSIS
+      Update Puppet module readme with PowerShell Module Manifest metadata.
+    .DESCRIPTION
+      Update Puppet module readme with PowerShell Module Manifest metadata and useful information about the vendored modules.
+    .PARAMETER PuppetModuleFolderPath
+      The path to the root folder of the Puppet module.
+    .PARAMETER PuppetModuleName
+      The name of the Puppet module
+    .PARAMETER PowerShellModuleManifestPath
+      The full path to the PowerShell module's manifest file.
+    .PARAMETER PowerShellModuleName
+      The name of the PowerShell module
+    .PARAMETER Confirm
+      Prompts for confirmation before overwriting the file
+    .PARAMETER WhatIf
+      Shows what would happen if the function runs.
+    .EXAMPLE
+      Update-PuppetModuleReadme -PuppetModuleFolderPath ./import/powershellget -PowerShellModuleManifestPath ./mymodule.psd1
+      This command will update `./import/powershellget/README.md` based on the metadata from `./mymodule.psd1`.
+  #>
+  [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+  param (
+    [string]$PowerShellModuleManifestPath,
+    [string]$PowerShellModuleName,
+    [string]$PuppetModuleFolderPath,
+    [string]$PuppetModuleName
+  )
+
+  begin {
+    Try {
+      $PuppetReadmeFilePath         = Resolve-Path (Join-Path $PuppetModuleFolderPath "README.md") -ErrorAction Stop
+      $PowerShellModuleManifestPath = Resolve-Path -Path $PowerShellModuleManifestPath -ErrorAction Stop
+      $PowerShellMetadata           = Import-PSFPowerShellDataFile -Path $PowerShellModuleManifestPath -ErrorAction Stop
+    } Catch {
+      # Rethrow any exceptions from the above commands
+      $PSCmdlet.ThrowTerminatingError($PSItem)
+    }
+
+    If ([string]::IsNullOrEmpty($PuppetModuleName)) {
+      $PuppetModuleName = Get-PuppetizedModuleName -Name $PowerShellModuleName
+    }
+  }
+
+  process {
+    $ReadmeParameters = @{
+      PowerShellModuleName        = $PowerShellModuleName
+      PowerShellModuleDescription = $PowerShellMetadata.Description
+      PowerShellModuleGalleryUri  = "https://www.powershellgallery.com/packages/$PowerShellModuleName/$($PowerShellMetadata.ModuleVersion)"
+      PowerShellModuleProjectUri  = $PowerShellMetadata.PrivateData.PSData.ProjectUri
+      PowerShellModuleVersion     = $PowerShellMetadata.ModuleVersion
+      PuppetModuleName            = $PuppetModuleName
+    }
+    $ReadmeContent = Get-ReadmeContent @ReadmeParameters
+    If ($PSCmdlet.ShouldProcess($PuppetModuleMetadataFilePath, "Overwrite Puppet Module Readme")) {
+      Out-Utf8File -Path $PuppetReadmeFilePath -InputObject $ReadmeContent
+    }
+  }
+
+  end {}
+}

--- a/src/internal/functions/Get-ReadmeContent.ps1
+++ b/src/internal/functions/Get-ReadmeContent.ps1
@@ -1,0 +1,156 @@
+function Get-ReadmeContent {
+  <#
+  .SYNOPSIS
+    Return the text for a Puppet Resource API Type given a DSC Resouce.
+  .DESCRIPTION
+    Return the text for a Puppet Resource API Type given a DSC Resouce.
+    It will return the text but _not_ directly write out the file.
+  .PARAMETER PuppetModuleName
+    The name of the puppet module
+  .PARAMETER PowerShellModuleName
+    The name of the PowerShell module being puppetized
+  .PARAMETER PowerShellModuleVersion
+    The version of the PowerShell module being puppetized
+  .PARAMETER PowerShellModuleGalleryUri
+    The full url to the PowerShell module on a nuget gallery
+  .PARAMETER PowerShellModuleProjectUri
+    The full url to the PowerShell module's project page/repository
+
+  .EXAMPLE
+    $Parameters = @{
+      PowerShellModuleName       = 'Foo.Bar'
+      PowerShellModuleGalleryUri = "https://www.powershellgallery.com/packages/Foo.Bar/1.0.0"
+      PowerShellModuleProjectUri = 'https://github.com/foo/Foo.Bar'
+      PowerShellModuleVersion    = '1.0.0'
+      PuppetModuleName           = 'foo_bar'
+    }
+    Get-ReadmeContent @Parameters
+
+    This command return a markdown readme for the puppetized foo_bar module.
+  #>
+  [cmdletbinding()]
+  param (
+    [OutputType([String])]
+    [string]$PowerShellModuleName,
+    [string]$PowerShellModuleDescription,
+    [string]$PowerShellModuleGalleryUri,
+    [string]$PowerShellModuleProjectUri,
+    [string]$PowerShellModuleVersion,
+    [string]$PuppetModuleName
+  )
+
+  Begin {
+    $BuilderModuleGalleryUri  = 'https://www.powershellgallery.com/packages/puppet.dsc'
+    $BuilderModuleRepository  = 'https://github.com/puppetlabs/PuppetDscBuilder'
+    $BaseProviderSource       = 'https://github.com/puppetlabs/ruby-pwsh/blob/master/lib/puppet/provider/dsc_base_provider.rb'
+    $ResourceApiOverview      = 'https://puppet.com/docs/puppet/latest/create_types_and_providers_resource_api.html'
+    $ResourceApiDocumentation = 'https://puppet.com/docs/puppet/latest/about_the_resource_api.html'
+    $dscForgePage             = 'https://forge.puppet.com/dsc'
+    $pwshlibForgePage         = 'https://forge.puppet.com/puppetlabs/pwshlib'
+    $pwshlibIssuesPage        = 'https://github.com/puppetlabs/ruby-pwsh/issues/new/choose'
+    $PowerShellGetUri         = 'https://github.com/PowerShell/PowerShellGet'
+    $NarrativeDocumentation   = 'https://puppetlabs.github.io/iac/news/roadmap/2020/03/30/dsc-announcement.html'
+  }
+
+  Process {
+    # No additional formatting should be needed
+    New-Object -TypeName System.String @"
+# $PuppetModuleName
+
+## Table of Contents
+
+1. [Description](#description)
+1. [Requirements](#requirements)
+1. [Usage](#usage)
+1. [Troubleshooting](#troubleshooting)
+
+## Description
+
+This is an auto-generated module, using the [Puppet DSC Builder]($BuilderModuleGalleryUri) to vendor and expose the [$PowerShellModuleName]($PowerShellModuleGalleryUri) PowerShell module's DSC resources as Puppet resources.
+The _functionality_ of this module comes entirely from the vendored PowerShell resources, which are pinned at [**v$PowerShellModuleVersion**]($PowerShellModuleGalleryUri).
+The PowerShell module describes itself like this:
+
+> _${PowerShellModuleDescription}_
+
+For information on troubleshooting to determine whether any encountered problems are with the Puppet wrapper or the DSC resource, see the [troubleshooting](#troubleshooting) section below.
+
+## Requirements
+
+This module, like all [auto-generated Puppetized DSC modules]($dscForgePage), relies on two important technologies in the Puppet stack: the [Puppet Resource API]($ResourceApiOverview) and the [`puppetlabs/pwshlib`]($pwshlibForgePage) Puppet module.
+
+The Resource API provides a simplified option for writing types and providers and is responsible for how this module is structured.
+The Resource API ships inside of Puppet starting with version 6.
+While it is _technically_ possible to add the Resource API functionality to Puppet 5.5.x, the DSC functionality has **not** been tested in this setup.
+For more information on the Resource API, review the [documentation]($ResourceApiDocumentation).
+
+The module also depends on the `pwshlib` module.
+This Puppet module includes two important things: the ruby-pwsh library for running PowerShell code from ruby and the base provider for DSC resources, which this module leverages.
+
+All of the actual work being done to call the DSC resources vendored with this module is in [this file]($BaseProviderSource) from the `pwshlib` module.
+This is important for troubleshooting and bug reporting, but doesn't impact your use of the module except that the end result will be that nothing works, as the dependency is not installed alongside this module!
+
+## Usage
+
+You can specify any of the DSC resources from this module like a normal Puppet resource in your manifests.
+The examples below use DSC resources from from the [`PowerShellGet`]($PowerShellGetUri) repository, regardless of what module you're looking at here;
+the syntax, not the specifics, is what's important.
+
+For reference documentation about the DSC resources exposed in this module, see the [Reference](REFERENCE.md) file.
+
+``````puppet
+# Include a meaningful title for your resource declaration
+dsc_psrepository { 'Add team module repo':
+    dsc_name               => 'foo',
+    # Note that we specify dsc_ensure; do NOT specify the Puppet
+    # ensure property, it exists only for the underlying system.
+    # You will always use dsc_ensure.
+    dsc_ensure             => present,
+    # This location is nonsense, can be any valid folder on your
+    # machine or in a share, any location the SourceLocation param
+    # for the DSC resource will accept.
+    dsc_sourcelocation     => 'C:\Program Files',
+    # You must always pass an enum fully lower-cased;
+    # Puppet is case sensitive even when PowerShell isn't
+    dsc_installationpolicy => untrusted,
+}
+
+dsc_psrepository { 'Trust public gallery':
+    dsc_name               => 'PSGallery',
+    dsc_ensure             => present,
+    dsc_installationpolicy => trusted,
+}
+
+dsc_psmodule { 'Make Ruby manageable via uru':
+  dsc_name   => 'RubyInstaller',
+  dsc_ensure => present,
+}
+``````
+
+For more information about using a built module, check out our [narrative documentation]($NarrativeDocumentation).
+
+## Troubleshooting
+
+<!-- TODO: move all generic docs into main PuppetDscBuilder README and link from here; minimize content that we would need to update! ->
+
+In general, there are three broad categories of problems:
+
+1. Problems with the way the underlying DSC resource works.
+1. Problems with the type definition, where you can't specify a valid set of properties for the DSC resource
+1. Problems with calling the underlying DSC resource - the parameters aren't being passed correctly or the resource can't be found
+
+Unfortunately, problems with the way the underlying DSC resource works are something we can't help _directly_ with.
+You'll need to [file an issue]($PowerShellModuleProjectUri) with the upstream maintainers for the [PowerShell module]($PowerShellModuleGalleryUri).
+
+Problems with the type definition are when a value that should be valid according to the DSC resource's documentation and code is not accepted by the Puppet wrapper. If and when you run across one of these, please [file an issue]($BuilderModuleRepository/issues/new/choose) with the Puppet DSC Builder; this is where the conversion happens and once we know of a problem we can fix it and regenerate the Puppet modules. To help us identify the issue, please specify the DSC module, version, resource, property and values that are giving you issues. Once a fix is available we will regenerate and release updated versions of this Puppet wrapper.
+
+Problems with calling the underlying DSC resource become apparent by comparing <value passed in in puppet> with <value received by DSC>. (TODO: include example debugging steps)
+In this case, please [file an issue]($pwshlibIssuesPage) with the [`puppetlabs/pwshlib`]($pwshlibForgePage) module, which is where the DSC base provider actually lives.
+We'll investigate and prioritize a fix and update the `puppetlabs/pwshlib` module.
+Updating to the pwshlib version with the fix will immediately take advantage of the improved functionality without waiting for this module to be reconverted and published.
+
+<!-- TODO: That all being said, here's some guidance on troubleshooting...-->
+"@
+  }
+
+  End {}
+}

--- a/src/puppet.dsc.psd1
+++ b/src/puppet.dsc.psd1
@@ -47,6 +47,7 @@
     'Initialize-PuppetModule'
     'Update-PuppetModuleFixture'
     'Update-PuppetModuleMetadata'
+    'Update-PuppetModuleReadme'
   )
 
   # Cmdlets to export from this module

--- a/src/puppet.dsc.psd1
+++ b/src/puppet.dsc.psd1
@@ -43,6 +43,7 @@
   FunctionsToExport = @(
     'Add-DscResourceModule'
     'ConvertTo-PuppetResourceApi'
+    'Get-PuppetizedModuleName'
     'Initialize-PuppetModule'
     'Update-PuppetModuleFixture'
     'Update-PuppetModuleMetadata'

--- a/src/tests/functions/Get-PuppetizedModuleName.Tests.ps1
+++ b/src/tests/functions/Get-PuppetizedModuleName.Tests.ps1
@@ -1,0 +1,15 @@
+Describe 'Get-PuppetizedModuleName' {
+  InModuleScope puppet.dsc {
+    Context 'Basic verification' {
+      It 'lower-cases module names' {
+        Get-PuppetizedModuleName 'xDSCSomething' | Should -MatchExactly "xdscsomething"
+      }
+      It 'replaces invalid characters' {
+        Get-PuppetizedModuleName 'xDSC::Something' | Should -MatchExactly "xdsc__something"
+      }
+      It 'deals with prefixed numbers' {
+        Get-PuppetizedModuleName '7zip' | Should -MatchExactly "a7zip"
+      }
+    }
+  }
+}

--- a/src/tests/functions/Get-ReadmeContent.Tests.ps1
+++ b/src/tests/functions/Get-ReadmeContent.Tests.ps1
@@ -1,0 +1,47 @@
+Describe 'Get-ReadmeContent' {
+  InModuleScope puppet.dsc {
+    Context 'Basic verification' {
+      # Copy fixtures over
+      # $ManifestFixtureFile = Resolve-Path -Path "$(Split-Path $PSScriptRoot -Parent)/fixtures/PowerShellGet.psd1"
+      # $ManifestFilePath = 'TestDrive:\PowerShellGet.psd1'
+      # Copy-Item -Path $ManifestFixtureFile -Destination $ManifestFilePath
+      $Parameters = @{
+        PowerShellModuleName        = 'Foo.Bar'
+        PowerShellModuleDescription = 'Foo and bar and baz!'
+        PowerShellModuleGalleryUri  = 'https://powershellgallery.com/Foo.Bar/1.0.0'
+        PowerShellModuleProjectUri  = 'https://github.com/Baz/Foo.Bar'
+        PowerShellModuleVersion     = '1.0.0'
+        PuppetModuleName            = 'foo_bar'
+      }
+
+      $Result = Get-ReadmeContent @Parameters
+
+      It 'Has the puppet module name as the title' {
+        $Result | Should -MatchExactly "# $($Parameters.PuppetModuleName)"
+      }
+      It 'Includes the link to the builder, the upstream module, and the module version in the first para' {
+        $Result | Should -MatchExactly "\[Puppet DSC Builder\]\(.+\)"
+        $Result | Should -MatchExactly "\[$($Parameters.PowerShellModuleName)\]\($($Parameters.PowerShellModuleGalleryUri)\)"
+        $Result | Should -MatchExactly "v$([Regex]::Escape($Parameters.PowerShellModuleVersion))"
+      }
+      It 'Includes the module description as a quote' {
+        $Result | Should -MatchExactly "> _$($Parameters.PowerShellModuleDescription)_"
+      }
+      It 'Links to the Resource API and pwshlib dependencies' {
+        $Result | Should -MatchExactly "\[Puppet Resource API\]\(.+\)"
+        $Result | Should -MatchExactly "\[puppetlabs/pwshlib\]\(.+\)"
+      }
+      It 'Links to the base provider on github' {
+        $Result | Should -MatchExactly "\(https://github.com/.+/dsc_base_provider.rb\)"
+      }
+      It 'Links to further narrative documentation' {
+        $Result | Should -MatchExactly '\[narrative documentation\]\(.+\)'
+      }
+      It 'Links to the issues page for the builder, the pwslib module, and the upstream module' {
+        $Result | Should -MatchExactly "\[file an issue\]\(.+puppetlabs/PuppetDscBuilder/issues/new/choose\)"
+        $Result | Should -MatchExactly "\[file an issue\]\(.+puppetlabs/ruby-pwsh/issues/new/choose\)"
+        $Result | Should -MatchExactly "\[file an issue\]\($($Parameters.PowerShellModuleProjectUri)\)"
+      }
+    }
+  }
+}

--- a/src/tests/functions/Update-PuppetModuleReadme.Tests.ps1
+++ b/src/tests/functions/Update-PuppetModuleReadme.Tests.ps1
@@ -1,0 +1,99 @@
+Describe 'Update-PuppetModuleReadme' {
+  InModuleScope puppet.dsc {
+    Context 'Basic Verification' {
+      # Setup fixtures
+      $PuppetFolderPath = 'TestDrive:\'
+      New-Item -Path "$PuppetFolderPath/README.md"
+      $ManifestFixtureFile = Resolve-Path -Path "$(Split-Path $PSScriptRoot -Parent)/fixtures/PowerShellGet.psd1"
+      $ManifestFilePath = 'TestDrive:\PowerShellGet.psd1'
+      Copy-Item -Path $ManifestFixtureFile -Destination $ManifestFilePath
+      # Import from the Manifest Fixture
+      $ManifestData = Import-PSFPowerShellDataFile -Path $ManifestFixtureFile
+
+      Context 'Parameter handling' {
+        Mock Import-PSFPowerShellDataFile { return $ManifestData }
+        Mock Get-ReadmeContent            { return 'Content' }
+        Mock Get-PuppetizedModuleName     { return 'foo' }
+        Mock Out-Utf8File                 { }
+
+        It 'Errors if the specified Puppet readme file cannot be found' {
+          $Parameters = @{
+            PowerShellModuleManifestPath = $ManifestFilePath
+            PowerShellModuleName = 'PowerShellGet'
+            PuppetModuleFolderPath = 'TestDrive:\foo\bar'
+            PuppetModuleName = 'powershellget'
+          }
+          # NB: This test may only work on English language test nodes?
+          { Update-PuppetModuleReadme @Parameters } | Should -Throw "Cannot find path 'TestDrive:\foo\bar\README.md' because it does not exist."
+        }
+        It 'Errors if the specified PowerShell module manifest cannot be found' {
+          $Parameters = @{
+            PowerShellModuleManifestPath = 'TestDrive:\foo\bar'
+            PowerShellModuleName = 'PowerShellGet'
+            PuppetModuleFolderPath = $PuppetFolderPath
+            PuppetModuleName = 'powershellget'
+          }
+          { Update-PuppetModuleReadme @Parameters  } | Should -Throw "Cannot find path 'TestDrive:\foo\bar' because it does not exist."
+        }
+        It 'Sets the Puppet module name if not specified' {
+          $Parameters = @{
+            PowerShellModuleManifestPath = $ManifestFilePath
+            PowerShellModuleName = 'PowerShellGet'
+            PuppetModuleFolderPath = $PuppetFolderPath
+          }
+          # Specified
+          { Update-PuppetModuleReadme @Parameters -PuppetModuleName override } | Should -Not -Throw
+          Assert-MockCalled Get-PuppetizedModuleName -Times 0
+          Assert-MockCalled Get-ReadmeContent -Times 1 -ParameterFilter {
+            $PuppetModuleName -ceq 'override'
+          }
+          # Unspecified
+          { Update-PuppetModuleReadme @Parameters } | Should -Not -Throw
+          Assert-MockCalled Get-PuppetizedModuleName -Times 1
+          Assert-MockCalled Get-ReadmeContent -Times 1 -ParameterFilter {
+            $PuppetModuleName -ceq 'foo'
+          }
+        }
+      }
+      Context 'Updating Readme' {
+        Mock Import-PSFPowerShellDataFile { return $ManifestData }
+        Mock Get-ReadmeContent            { return 'Content' }
+        Mock Out-Utf8File                 { }
+        Mock Get-PuppetizedModuleName     { }
+
+        $Parameters = @{
+          PowerShellModuleManifestPath = $ManifestFilePath
+          PowerShellModuleName = 'PowerShellGet'
+          PuppetModuleFolderPath = $PuppetFolderPath
+          PuppetModuleName = 'powershellget'
+        }
+        Update-PuppetModuleReadme @Parameters
+
+        It 'Retrieves the README text' {
+          Assert-MockCalled Get-ReadmeContent -Times 1
+        }
+        It 'Writes the file once' {
+          Assert-MockCalled Out-Utf8File -Times 1
+        }
+        It 'Passes the PowerShell module name' {
+          Assert-MockCalled Get-ReadmeContent -Times 1 -ParameterFilter {
+            $PowerShellModuleName -eq $Parameters.PowerShellModuleName
+          }
+        }
+        It 'Constructs the PowerShell gallery link' {
+          Assert-MockCalled Get-ReadmeContent -Times 1 -ParameterFilter {
+            $PowerShellModuleGalleryUri -eq "https://www.powershellgallery.com/packages/$($Parameters.PowerShellModuleName)/$($ManifestData.ModuleVersion)"
+          }
+        }
+        It 'Passes the PowerShell module description, project uri, and version' {
+          $Description
+          Assert-MockCalled Get-ReadmeContent -Times 1 -ParameterFilter {
+            $PowerShellModuleDescription -eq $ManifestData.Description -and
+            $PowerShellModuleProjectUri  -eq $ManifestData.PrivateData.PSData.ProjectUri -and
+            $PowerShellModuleVersion     -eq $ManifestData.ModuleVersion
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit takes an initial pass at adding an automatically generated readme file to the Puppetized module, covering basic usage and clarifying that the module is autogenerated, as well as pointing readers in the right direction for troubleshooting, filing issues, and investigating.

The troubleshooting section is left a little bare as the bulk of this documentation is scheduled to be written in [IAC-716](https://tickets.puppetlabs.com/browse/IAC-716).

This readme should be updated as additional documentation is written to reflect best practices and functionality.

This PR also adds the `Get-PuppetizedName` helper function which returns a munged PowerShell module name for use as a Puppet module name; this was necessary as it was discovered during testing that numerous PowerShell modules are not valid Puppet modules when they are downcased; they still contain illegal characters or start with a number.