### PR TITLE
(MAINT) Check stdout for pdk success messages

### DIFF
--- a/src/internal/functions/Invoke-PdkCommand.ps1
+++ b/src/internal/functions/Invoke-PdkCommand.ps1
@@ -46,7 +46,7 @@ Function Invoke-PdkCommand {
   
   process {
     $PdkResults = Start-Job -ScriptBlock $ScriptBlock | Wait-Job
-    $PdkSuccessMessage = $PDkResults.ChildJobs[0].Error.Exception |
+    $PdkSuccessMessage = $PdkResults.ChildJobs[0].Error.Exception, $PdkResults.ChildJobs[0].Output |
       Where-Object -FilterScript $SuccessFilterScript
     If ($null -eq $PdkSuccessMessage) {
       Throw "Command '$Command' failed:`n`t$($PdkResults.ChildJobs[0].Error[-1].Exception -Replace 'System.Management.Automation.RemoteException:', $null)"


### PR DESCRIPTION
Prior to this PR the `Invoke-PdkCommand` private function only checked the `stderr` logs for a PDK command to verify whether or not it was successful.

Since the PDK does not consistently send information to `stderr` or `stdout` indicating successful completion of a command, this PR updates the success filter to work regardless of output stream.