### PR TITLE
(MAINT) Ensure New-PuppetDscModule populates readme

### DIFF
--- a/src/functions/New-PuppetDscModule.ps1
+++ b/src/functions/New-PuppetDscModule.ps1
@@ -74,15 +74,19 @@ Function New-PuppetDscModule {
         Add-DscResourceModule -Name $PowerShellModuleName -Path $VendoredDscResourcesDirectory -RequiredVersion $PowerShellModuleVersion
 
         # Update the Puppet module metadata
+        $PowerShellModuleManifestPath = (Resolve-Path "$VendoredDscResourcesDirectory/$PowerShellModuleName/$PowerShellModuleName.psd1")
         $MetadataParameters = @{
           PuppetModuleFolderPath       = $PuppetModuleRootFolderDirectory
-          PowerShellModuleManifestPath = (Resolve-Path "$VendoredDscResourcesDirectory/$PowerShellModuleName/$PowerShellModuleName.psd1")
+          PowerShellModuleManifestPath = $PowerShellModuleManifestPath
           PuppetModuleAuthor           = $PuppetModuleAuthor
         }
         Update-PuppetModuleMetadata @MetadataParameters
 
         # Update the Puppet module test fixtures
         Update-PuppetModuleFixture -PuppetModuleFolderPath $PuppetModuleRootFolderDirectory
+
+        # Write the Puppet module README
+        Update-PuppetModuleReadme -PuppetModuleFolderPath $PuppetModuleRootFolderDirectory -PowerShellModuleManifestPath $PowerShellModuleManifestPath
 
         # The PowerShell Module path needs to be munged because the Get-DscResource function always and only
         # checks the PSModulePath for DSC modules; you CANNOT point to a module by path.

--- a/src/tests/functions/New-PuppetDscModule.Tests.ps1
+++ b/src/tests/functions/New-PuppetDscModule.Tests.ps1
@@ -7,6 +7,7 @@ Describe "New-PuppetDscModule" {
       Mock Resolve-Path {$Path}
       Mock Update-PuppetModuleMetadata {}
       Mock Update-PuppetModuleFixture {}
+      Mock Update-PuppetModuleReadme {}
       Mock Set-PSModulePath {}
       Mock Get-DscResource {
         [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo[]]@(
@@ -53,6 +54,12 @@ Describe "New-PuppetDscModule" {
         Assert-MockCalled Update-PuppetModuleFixture -ParameterFilter {
           $PuppetModuleFolderPath -match 'import(/|\\)foo'
         } -Times 1
+      }
+      It 'Updates the Puppet README based on the PowerShell metadata' {
+        Assert-MockCalled Update-PuppetModuleReadme -ParameterFilter {
+          $PuppetModuleFolderPath       -match 'import(/|\\)foo' -and
+          $PowerShellModuleManifestPath -match 'import(/|\\)foo\S+(/|\\)foo(/|\\)foo.psd1'
+        }
       }
       It 'Temporarily sets the PSModulePath' {
         Assert-MockCalled Set-PSModulePath -ParameterFilter {
@@ -101,6 +108,7 @@ Describe "New-PuppetDscModule" {
         Mock Resolve-Path {$Path}
         Mock Update-PuppetModuleMetadata {}
         Mock Update-PuppetModuleFixture {}
+        Mock Update-PuppetModuleReadme {}
         Mock Set-PSModulePath {}
         Mock Get-DscResource {}
         Mock ConvertTo-PuppetResourceApi {}
@@ -142,6 +150,7 @@ Describe "New-PuppetDscModule" {
           Mock Resolve-Path {$Path}
           Mock Update-PuppetModuleMetadata {}
           Mock Update-PuppetModuleFixture {}
+          Mock Update-PuppetModuleReadme {}
           Mock Set-PSModulePath {}
           Mock Get-DscResource {}
           Mock ConvertTo-PuppetResourceApi {}
@@ -181,6 +190,7 @@ Describe "New-PuppetDscModule" {
         Mock Resolve-Path {$Path}
         Mock Update-PuppetModuleMetadata {}
         Mock Update-PuppetModuleFixture {}
+        Mock Update-PuppetModuleReadme {}
         Mock Set-PSModulePath {}
         Mock Get-DscResource {}
         Mock ConvertTo-PuppetResourceApi {}
@@ -204,6 +214,7 @@ Describe "New-PuppetDscModule" {
         Mock Resolve-Path {$Path}
         Mock Update-PuppetModuleMetadata {}
         Mock Update-PuppetModuleFixture {}
+        Mock Update-PuppetModuleReadme {}
         Mock Set-PSModulePath {}
         Mock Get-DscResource {}
         Mock ConvertTo-PuppetResourceApi {}


### PR DESCRIPTION
Prior to this commit the call to `Update-PuppetModuleReadme` was erroneously left out of `New-PuppetDscModule`, meaning that the README that shipped with each auto-generated module was the default template readme supplied by the PDK instead of the useful and specific one generated for each DSC module.

This commit adds the call and updates tests to reflect it.