### PR TITLE
(IAC-740) Map embedded CIM instances if running elevated

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
 build: off
 test_script:
   - ps: '& .\src\tests\pester.ps1'
-  - ps: '& .\build.ps1 -PowerShellModuleName PowerShellGet -ErrorAction Stop'
+  - ps: '& .\build.ps1 -PowerShellModuleName PowerShellGet -ErrorAction Stop -Verbose -PassThru'
 notifications:
   - provider: Email
     on_build_success: false

--- a/build.ps1
+++ b/build.ps1
@@ -1,34 +1,48 @@
 <#
-  .SYNOPSIS
-    Puppetize a PowerShell module with DSC resources
-  .DESCRIPTION
-    This script builds a Puppet Module which wraps and calls PowerShell DSC resources
-    via the Puppet resource_api. This module:
+    .SYNOPSIS
+      Puppetize a PowerShell module with DSC resources
+    .DESCRIPTION
+      This function builds a Puppet Module which wraps and calls PowerShell DSC resources
+      via the Puppet resource_api. This module:
 
-    - Includes a base resource_api provider which relies on ruby-pwsh and knows how to invoke DSC resources
-    - Includes a type for each DSC resource, pulling in the appropriate metadata including help, default value
-      and mandatory status, as well as whether or not it includes an embedded mof.
-    - Allows for the tracking of changes on a property-by-property basis while using DSC and Puppet together
-  .PARAMETER PowerShellModuleName
-    The name of the PowerShell module on the gallery which has DSC resources you want to Puppetize
-  .PARAMETER PowerShellModuleVersion
-    The version of the PowerShell module on the gallery which has DSC resources you want to Puppetize.
-    If left blank, will default to latest available.
-  .PARAMETER PuppetModuleName
-    The name of the Puppet module for the wrapper; if not specified, will default to the downcased name of
-    the module to adhere to Puppet naming conventions.
-  .EXAMPLE
-    .\build.ps1 -PowerShellModuleName PowerShellGet -PowerShellModuleVersion 2.2.3
-  .NOTES
-    For right now, we require the powershell-yaml module and the PDK
-#>
-[CmdletBinding()]
-param(
-  [string]$PuppetModuleName,
-  [string]$PuppetModuleAuthor,
-  [string]$PowerShellModuleName,
-  [string]$PowerShellModuleVersion
-)
+      - Includes a base resource_api provider which relies on ruby-pwsh and knows how to invoke DSC resources
+      - Includes a type for each DSC resource, pulling in the appropriate metadata including help, default value
+        and mandatory status, as well as whether or not it includes an embedded mof.
+      - Allows for the tracking of changes on a property-by-property basis while using DSC and Puppet together
+    .PARAMETER PowerShellModuleName
+      The name of the PowerShell module on the gallery which has DSC resources you want to Puppetize
+    .PARAMETER PowerShellModuleVersion
+      The version of the PowerShell module on the gallery which has DSC resources you want to Puppetize.
+      If left blank, will default to latest available.
+    .PARAMETER PuppetModuleName
+      The name of the Puppet module for the wrapper; if not specified, will default to the downcased name of
+      the module to adhere to Puppet naming conventions.
+    .PARAMETER PuppetModuleAuthor
+      The name of the Puppet module author; if not specified, will default to your PDK configuration's author.
+    .PARAMETER OutputDirectory
+      The folder in which to build the Puppet module. Defaults to a folder called import in the current location.
+    .PARAMETER PassThru
+      If specified, the function returns the path to the root folder of the Puppetized module on the filesystem.
+    .PARAMETER Confirm
+      Prompts for confirmation before creating the Puppet module
+    .PARAMETER WhatIf
+      Shows what would happen if the function runs.
+    .EXAMPLE
+      Build.ps1 -PowerShellModuleName PowerShellGet -PowerShellModuleVersion 2.2.3
+
+      This function will create a new Puppet module, powershellget, which vendors and puppetizes the PowerShellGet
+      PowerShell module at version 2.2.3 and its dependencies, exposing the DSC resources as Puppet resources.
+  #>
+  [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+  param(
+    [Parameter(Mandatory=$True)]
+    [string]$PowerShellModuleName,
+    [string]$PowerShellModuleVersion,
+    [string]$PuppetModuleName,
+    [string]$PuppetModuleAuthor,
+    [string]$OutputDirectory,
+    [switch]$PassThru
+  )
 
 Import-Module PuppetDevelopmentKit
 Import-Module "$PSScriptRoot/src/puppet.dsc.psd1" -Force

--- a/extras/install.ps1
+++ b/extras/install.ps1
@@ -22,6 +22,7 @@ $PowerShellModules = @(
   @{ Name = 'PSDepend' }
   @{ Name = 'xPSDesiredStateConfiguration' }
   @{ Name = 'PSDscResources' ; RequiredVersion = '2.12.0.0' }
+  @{ Name = 'AccessControlDsc' ; RequiredVersion = '1.4.0.0' }
 )
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 ForEach ($Module in $PowerShellModules) {

--- a/src/internal/functions/Get-CimClassPropertiesList.ps1
+++ b/src/internal/functions/Get-CimClassPropertiesList.ps1
@@ -1,0 +1,36 @@
+Function Get-CimClassPropertiesList {
+  <#
+    .SYNOPSIS
+      Retrieve an iterable list of CIM Class properties
+    .DESCRIPTION
+      Retrieve an iterable list of CIM Class properties, by default from the
+      DSC namespace, for introspecting to define as a Puppet Type.
+    .PARAMETER ClassName
+      The CIM Class name to look up; for DSC Resources, usually the ResourceType
+      for that DSC resource, as surfaced by Get-DscResource.
+    .PARAMETER Namespace
+      The CIM namespace to look in; by default, the root DSC namespace.
+    .EXAMPLE
+      Get-CimClassPropertiesList -ClassName NTFSAccessEntry
+      
+      This command will look in the DSC namespace for the NTFSAccessEntry CIM
+      Class and, if loaded, return its properties as an iterable array.
+  #>
+  [cmdletbinding()]
+  param(
+    [Parameter(Mandatory=$true)]
+    [string]$ClassName,
+    [string]$Namespace = 'root\Microsoft\Windows\DesiredStateConfiguration'
+  )
+
+  Begin {}
+
+  Process {
+    # For some reason, the base list is not iterable, so make it an iterable variable
+    Get-CimClass -ClassName $ClassName -Namespace $Namespace |
+      Select-Object -ExpandProperty CimClassProperties |
+      ForEach-Object {$_}
+  }
+
+  End {}
+}

--- a/src/internal/functions/Get-DscResourceParameterInfo.ps1
+++ b/src/internal/functions/Get-DscResourceParameterInfo.ps1
@@ -1,28 +1,29 @@
 function Get-DscResourceParameterInfo {
   <#
-  .SYNOPSIS
-    Retrieve the DSC Parameter information, if possible
+    .SYNOPSIS
+      Retrieve the DSC Parameter information, if possible
 
     .DESCRIPTION
-    Given a DSC Resource Info object, introspect on the source (if possible) to return information about
-    the resources parameters, including their help text, whether or not they are mandatory for calling the
-    resource with the Get method, and whether or not they are mandatory for calling the resource with the
-    Set method.
+      Given a DSC Resource Info object, introspect on the source (if possible) to return information about
+      the resources parameters, including their help text, whether or not they are mandatory for calling the
+      resource with the Get method, and whether or not they are mandatory for calling the resource with the
+      Set method.
 
-    This information can be reliably retrieved if the DSC resource is implemented in PowerShell and is
-    not class based. Otherewise, best guesses are made about the mandatory status of the parameters via
-    the Required attribute and the help information is null.
+      This information can be reliably retrieved if the DSC resource is implemented in PowerShell and is
+      not class based. Otherewise, best guesses are made about the mandatory status of the parameters via
+      the Required attribute and the help information is null.
 
     .PARAMETER DscResource
-    A Dsc Resource Info object, as returned by Get-DscResource.
+      A Dsc Resource Info object, as returned by Get-DscResource.
 
-  .EXAMPLE
-    Get-DscResource -Name PSRepository | Get-DscResourceParameterInfo
+    .EXAMPLE
+      Get-DscResource -Name PSRepository | Get-DscResourceParameterInfo
 
-    Retrieve the Parameter information from the AST for the PSRepository Dsc Resource.
+      Retrieve the Parameter information from the AST for the PSRepository Dsc Resource.
   #>
   [CmdletBinding()]
   param (
+    [Parameter(ValueFromPipeline)]
     [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]$DscResource
   )
 

--- a/src/internal/functions/Get-DscResourceParameterInfoByCimClass.ps1
+++ b/src/internal/functions/Get-DscResourceParameterInfoByCimClass.ps1
@@ -1,0 +1,148 @@
+Function Get-DscResourceParameterInfoByCimClass {
+  <#
+    .SYNOPSIS
+      Retrieve the DSC Parameter information, if possible, by CIM Instance.
+
+    .DESCRIPTION
+      Given a DSC Resource Info object, load its CIM Class by invoking it once (ignoring errors) and then
+      introspecting its CIM class information in the DSC namespace. This requires running with administrator
+      privileges, unfortunately, as access to the CIM classes is privilege-gated.
+
+      It will discover help documentation if it is surfaced in the CIM class (not all resources do so), will
+      retrieve and map embedded CIM instances (which `Get-DscResourceParameterInfo` cannot do), but cannot
+      retrieve default values as these are not mapped.
+
+    .PARAMETER DscResource
+      A Dsc Resource Info object, as returned by Get-DscResource.
+
+    .EXAMPLE
+      Get-DscResource -Name PSRepository | Get-DscResourceParameterInfoByCimClass
+
+      Retrieve the Parameter information from the CIM class for the PSRepository Dsc Resource.
+  #>
+  [CmdletBinding()]
+  param (
+    [Parameter(ValueFromPipeline)]
+    [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]$DscResource
+  )
+
+  Begin {}
+
+  Process {
+    # We can assume it will find the right version because this is only ever called after we've munged the PSModulePath
+    $ModulePath = Get-Module -ListAvailable -Name $DscResource.ModuleName | Select-Object -ExpandProperty Path
+    # Invoke once to load the CIM class information, ignore all errors
+    Initialize-DscResourceCimClass -Name $DscResource.Name -ModuleName $ModulePath -ModuleVersion $DscResource.Version -ErrorAction Stop
+
+    # Look for embedded instances, store them for type-definition interpolation.
+    $DefinedEmbeddedInstances = @{}
+    $EmbeddedInstanceTypes = Get-EmbeddedCimInstance -ClassName $DscResource.ResourceType -Recurse
+    If ($EmbeddedInstanceTypes.count -gt 0) {
+      # Parse Embedded Instances in reverse, which should figure out nested instances before those that contain them
+      [array]::Reverse($EmbeddedInstanceTypes)
+      ForEach ($InstanceType in $EmbeddedInstanceTypes) {
+        # Handle credential objects separately as they are well-known constructs
+        If ($InstanceType -eq 'MSFT_Credential') {
+          $DefinedEmbeddedInstances.$InstanceType = 'Struct[{ user => String[1], password => Sensitive[String[1]] }]'
+        } Else {
+          # Capture the metadata in order to parse the Puppet type definition and retrieve the cim instance types.
+          $EmbeddedInstanceMetadata = @{}
+          $EmbeddedInstanceMetadata.$InstanceType = @{
+            cim_instance_type = "'$($InstanceType.ToLowerInvariant())'"
+          }
+          $CimClassProperties = Get-CimClassPropertiesList -ClassName $InstanceType
+          ForEach($Property in $CimClassProperties) {
+            If ($Property.ReferenceClassName -in $DefinedEmbeddedInstances.Keys) {
+              # Handle nested instances, wrapping them in the Array datatype if necessary
+              If ($Property.CimType -match 'Array') {
+                $EmbeddedInstanceMetadata.$InstanceType.$($Property.Name) = "Array[$($DefinedEmbeddedInstances.($Property.ReferenceClassName))]"
+              } Else {
+                $EmbeddedInstanceMetadata.$InstanceType.$($Property.Name) = $DefinedEmbeddedInstances.($Property.ReferenceClassName)
+              }
+            } Else {
+              # If it's not a CIM instance the standard type mapper can handle it.
+              $EmbeddedInstanceMetadata.$InstanceType.$($Property.Name) = Get-PuppetDataType -DscResourceProperty @{
+                Values       = $Property.Qualifiers['Values'].Value
+                IsMandatory  = $Property.Flags -Match 'Required'
+                # Replace the Array identifier with [] to match current expectations
+                PropertyType = $Property.CimType -Replace '(\S+)Array$','$1[]'
+              }
+            }
+          }
+          # Nested CIM instances need to be reassembled into readable Structs; but we want to increase the indentation level by one
+          # so that it's more visually distinct in the end file
+          $StructComponents = $EmbeddedInstanceMetadata.$InstanceType.Keys |
+            ForEach-Object -Process { "$($_.ToLowerInvariant()) => $($EmbeddedInstanceMetadata.$InstanceType.$_ -replace "`n", "`n  ")" }
+          # Assemble the current CIM instance as a struct, strip out any double quotes to prevent breaking parsing
+          $DefinedEmbeddedInstances.$InstanceType = "Struct[{`n  $($StructComponents -join ",`n  " -replace '"')`n}]"
+        }
+      }
+    }
+
+    # Do some slight property handling to ignore properties we don't care about.
+    # Minimally adapted from Ansible's implementation:
+    # - https://github.com/ansible-collections/ansible.windows/blob/master/plugins/modules/win_dsc.ps1#L42-L62
+    # Which itself borrows from core DSC:
+    # - https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/DscSupport/CimDSCParser.cs#L1203
+    $PropertiesToDiscard = @('ConfigurationName', 'DependsOn', 'ModuleName', 'ModuleVersion', 'ResourceID', 'SourceInfo')
+    $DscResourceCimClassProperties = Get-CimClassPropertiesList -ClassName $DscResource.ResourceType |
+      Where-Object {
+        $_.Name -notin $PropertiesToDiscard -and
+        -not $_.Flags.HasFlag([Microsoft.Management.Infrastructure.CimFlags]::ReadOnly)
+      }
+
+    $DscResourceMetadata = @{}
+
+    # Similarly to how the properties were resolved for embedded CIM instances, resolve them for each property
+    ForEach($Property in $DscResourceCimClassProperties) {
+      $DscResourceMetadata.$($Property.Name) = [ordered]@{
+        Name = $Property.Name.ToLowerInvariant()
+        # The one thing we *can't* retrieve here is the default values; they still apply, but they're
+        # not exposed in the definition here for some reason. In the alternate implementation, we can
+        # only retrieve default values by parsing the AST, so this is acceptable, if not ideal.
+        DefaultValue = $null
+        Help = $Property.Qualifiers['Description'].Value
+        mandatory_for_get = ($Property.Flags -Match 'Required').ToString().ToLowerInvariant()
+        mandatory_for_set = ($Property.Flags -Match 'Required').ToString().ToLowerInvariant()
+        mof_is_embedded   = 'false'
+      }
+      If ($Property.ReferenceClassName -in $DefinedEmbeddedInstances.Keys) {
+        $DscResourceMetadata.$($Property.Name).mof_is_embedded = 'true'
+        $MofType = $Property.ReferenceClassName
+        # Munge the type name per the expectations/surface from Get-DscResource and existing provider.
+        If ($MofType -eq 'MSFT_Credential') { $MofType = "PSCredential"}
+        $DscResourceMetadata.$($Property.Name).mof_type = if ($Property.CimType -match 'Array') {
+                                                            "$MofType[]"
+                                                          } Else {
+                                                            $MofType
+                                                          }
+        # Split the definition for the struct and toss away the cim_instance_type key as this is a top-level property
+        # and that information is captured in the mof_type key already.
+        $SplitDefinition = $DefinedEmbeddedInstances.($Property.ReferenceClassName) -split "`n" |
+          Where-Object -FilterScript {$_ -notmatch "cim_instance_type => '$($Property.ReferenceClassName)'"}
+        # Recombine the struct definition appropriately mapped as an array or singleton
+        If ($Property.CimType -match 'Array') {
+          $DscResourceMetadata.$($Property.Name).Type = """Array[$($SplitDefinition -Join "`n")]"""
+        } Else {
+          $DscResourceMetadata.$($Property.Name).Type = """$($SplitDefinition -Join "`n")"""
+        }
+      } Else {
+        $DscResourceMetadata.$($Property.Name).mof_type = $Property.CimType -Replace '(\S+)Array$','$1[]'
+        $DscResourceMetadata.$($Property.Name).Type     = Get-PuppetDataType -DscResourceProperty @{
+          Values       = $Property.Qualifiers['Values'].Value
+          IsMandatory  = $Property.Flags -Match 'Required'
+          # Replace the Array identifier with [] to match current expectations
+          PropertyType = $Property.CimType -Replace '(\S+)Array$','[$1[]]'
+        }
+      }
+    }
+
+    ForEach ($Property in $DscResourceMetadata.Keys) {
+      # Each object has the Name, DefaultValue, Help, mandatory_for_get, mandatory_for_set, mof_type, & Type properties
+      # This is the surface that Get-TypeParameterContent expects for processing a resource.
+      [PSCustomObject]$DscResourceMetadata.$Property
+    }
+  }
+
+  End {}
+}

--- a/src/internal/functions/Get-DscResourceTypeInformation.ps1
+++ b/src/internal/functions/Get-DscResourceTypeInformation.ps1
@@ -59,7 +59,9 @@ Function Get-DscResourceTypeInformation {
     [object]$Module
   )
 
-  Begin{}
+  Begin{
+    $RunningElevated = Test-RunningElevated
+  }
 
   Process {
     # Retrieve the DSC Resource information from the system unless passed directly
@@ -73,10 +75,15 @@ Function Get-DscResourceTypeInformation {
       $DscResourceToProcess = $DscResource
     }
     ForEach ($Resource in $DscResourceToProcess) {
+      $Value = If ($RunningElevated) {
+        Get-DscResourceParameterInfoByCimClass -DscResource $Resource
+      } Else {
+        Get-DscResourceParameterInfo -DscResource $Resource
+      }
       $Parameters = @{
         MemberType = 'NoteProperty'
         Name       = 'ParameterInfo'
-        Value      = (Get-DscResourceParameterInfo -DscResource $Resource)
+        Value      = $Value
         PassThru   = $True
       }
       $Resource | Add-Member @Parameters

--- a/src/internal/functions/Get-EmbeddedCimInstance.ps1
+++ b/src/internal/functions/Get-EmbeddedCimInstance.ps1
@@ -1,0 +1,49 @@
+Function Get-EmbeddedCimInstance {
+  <#
+    .SYNOPSIS
+      Retrieve CIM instances discovered in a CIM Class's definition
+    .DESCRIPTION
+      Retrieve CIM instances discovered in a CIM Class's definition,
+      returning their class names. Optionally, recurse through the
+      list of CIM instances to discover more deeply nested classes.
+    .PARAMETER ClassName
+      The CIM Class name to look up; for DSC Resources, usually the ResourceType
+      for that DSC resource, as surfaced by Get-DscResource.
+    .PARAMETER Namespace
+      The CIM namespace to look in; by default, the root DSC namespace.
+    .PARAMETER Recurse
+      If specified, will recursively search discovered embedded instances for
+      any embedded instances they may contain, and so on.
+    .EXAMPLE
+      Get-EmbeddedCimInstance -ClassName NTFSAccessEntry -Recurse
+      This command will look in the DSC namespace for the NTFSAccessEntry CIM
+      Class and, if loaded, search through it for propereties which are CIM
+      instances, then recursively search those classes for their own embedded
+      instances, returning the full list of discovered CIM classes which were
+      found to be embedded.
+  #>
+  param(
+    [Parameter(Mandatory=$true)]
+    [string]$ClassName,
+    [string]$Namespace = 'root\Microsoft\Windows\DesiredStateConfiguration',
+    [switch]$Recurse
+  )
+
+  Begin {}
+
+  Process {
+    [string[]]$EmbeddedInstanceTypes = Get-CimClassPropertiesList -ClassName $ClassName -Namespace $Namespace |
+      Select-Object -ExpandProperty Qualifiers |
+      Where-Object  -FilterScript {$_.Name -eq 'EmbeddedInstance'} |
+      Select-Object -ExpandProperty Value
+    If ($Recurse) {
+      ForEach ($EmbeddedInstanceType in $EmbeddedInstanceTypes) {
+        $EmbeddedInstanceTypes += Get-EmbeddedCimInstance -ClassName $EmbeddedInstanceType -Namespace $Namespace -Recurse
+      }
+    }
+    # Sometimes a null gets added to the list for some reason, but only in testing; discard null values
+    $EmbeddedInstanceTypes | Where-Object {![string]::IsNullOrEmpty($_)}
+  }
+
+  End {}
+}

--- a/src/internal/functions/Get-TypeParameterContent.ps1
+++ b/src/internal/functions/Get-TypeParameterContent.ps1
@@ -25,7 +25,7 @@ Function Get-TypeParameterContent {
   ForEach ($Parameter in $ParameterInfo) {
     New-Object -TypeName System.String @"
     dsc_$($Parameter.name): {
-      type: $($Parameter.Type),
+      type: $($Parameter.Type -split "`n" -join "`n            "),
 $(
   If ([string]::IsNullOrEmpty($Parameter.Help)) {
     "      desc: %q{},"

--- a/src/internal/functions/Initialize-DscResourceCimClass.ps1
+++ b/src/internal/functions/Initialize-DscResourceCimClass.ps1
@@ -1,0 +1,38 @@
+Function Initialize-DscResourceCimClass {
+  <#
+    .SYNOPSIS
+      Invoke a DSC Resource once to load its CIM class
+    .DESCRIPTION
+      Invoke a DSC Resource once to load its CIM class into the CIM namespace
+      for DSC, allowing other commands to introspect that CIM class.
+    .EXAMPLE
+      Initialize-DscResourceCimClass -Name PSRepository -ModuleName PowerShellGet -ModuleVersion 2.1.3
+      This will assemble the minimum parameters required to invoke the PSRepository resource with the
+      Get method, ignoring any/all errors and then do so. Once the invocation has completed, the CIM
+      Class is then loaded for other commands to introspect.
+  #>
+  [cmdletbinding()]
+  param(
+    [string]$Name,
+    [string]$ModuleName,
+    [string]$ModuleVersion
+  )
+  $InvokeParams = @{
+    Name       = $Name
+    Method     = 'Get'
+    Property   = @{foo = 1}
+    ModuleName = @{
+      ModuleName    = $ModuleName
+      ModuleVersion = $ModuleVersion
+    }
+    ErrorAction = 'Stop'
+  }
+  Try {
+    Invoke-DscResource @InvokeParams
+  } Catch {
+    # We only care if the resource can't be found, not if it fails while executing
+    if ($_.Exception.Message -match '(Resource \w+ was not found|The PowerShell DSC resource .+ does not exist at the PowerShell module path nor is it registered as a WMI DSC resource)') {
+      $PSCmdlet.ThrowTerminatingError($_)
+    }
+  }
+}

--- a/src/internal/functions/Test-RunningElevated.ps1
+++ b/src/internal/functions/Test-RunningElevated.ps1
@@ -1,0 +1,12 @@
+Function Test-RunningElevated {
+  <#
+  .SYNOPSIS
+    Returns whether or not the current session is running with elevated privileges
+  .DESCRIPTION
+    Returns whether or not the current session is running with elevated privileges
+  #>
+  [cmdletbinding()]
+  [OutputType([Boolean])]
+  Param()
+  ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')
+}

--- a/src/internal/functions/Test-SymLinkedItem.ps1
+++ b/src/internal/functions/Test-SymLinkedItem.ps1
@@ -1,0 +1,44 @@
+Function Test-SymLinkedItem {
+  <#
+    .SYNOPSIS
+      Determine if a specified path is a symlink
+    .DESCRIPTION
+      Determine if a specified path is a symlink or, if recursing, if that path is itself
+      inside a symlink further up the path.
+    .PARAMETER Path
+      The path to introspect to learn whether or not it is a symlink.
+    .PARAMETER Recurse
+      If this switch is specified the command will look at each parent node in the path
+      to see if the specified path is itself inside a symlinked folder.
+    .EXAMPLE
+      Test-SymLinkedItem -Path C:/foo/bar/baz -Recurse
+
+      This command will first check to see if `baz` is a symlinked item, and, if it is,
+      return True. If it is *not*, it will then check the parent folder, `bar`, and if
+      that folder is not symlinked, check `foo`, and then `C:/`. If no part of the path
+      is a symlink it will return False, otherwise it will immediately return True when
+      it discovers part of the path is symlinked.
+  #>
+  [cmdletbinding()]
+  [OutputType([Boolean])]
+  Param(
+    [Parameter(Mandatory=$true)]
+    [string]$Path,
+    [switch]$Recurse
+  )
+
+  $SymLinkedItem = Get-Item -Path $Path -Force -ErrorAction SilentlyContinue |
+    Where-Object -FilterScript {![string]::IsNullOrEmpty($_.LinkType)}
+  If ($null -ne $SymLinkedItem) {
+    return $true
+  } ElseIf ($Recurse) {
+    $ParentPath = Split-Path -Path $Path -Parent
+    if ([string]::IsNullOrEmpty($ParentPath)) {
+      return $false
+    } else {
+      return (Test-SymLinkedItem -Path $ParentPath -Recurse)
+    }
+  } Else {
+    return $false
+  }
+}

--- a/src/tests/functions/Get-CimClassPropertiesList.Tests.ps1
+++ b/src/tests/functions/Get-CimClassPropertiesList.Tests.ps1
@@ -1,0 +1,24 @@
+Describe 'Get-CimClassPropertiesList' {
+  InModuleScope puppet.dsc {
+    Context 'basic functionality' {
+      Mock Get-CimClass {
+        [pscustomobject]@{
+          CimClassProperties = @('foo', 'bar', 'baz')
+        }
+      }
+      $Result = Get-CimClassPropertiesList -ClassName Example 
+      It 'returns every discovered property for the CIM class' {
+        $Result.count | Should -Be 3
+        $Result[0]    | Should -Be 'foo'
+      }
+      It 'Calls Get-CimClass once' {
+        Assert-MockCalled -CommandName Get-CimClass -Times 1
+      }
+      It 'looks in the DSC namespace by default' {
+        Assert-MockCalled -CommandName Get-CimClass -Times 1 -ParameterFilter {
+          $Namespace -eq 'root\Microsoft\Windows\DesiredStateConfiguration'
+        }
+      }
+    }
+  }
+}

--- a/src/tests/functions/Get-DscResourceParameterInfoByCimClass.Tests.ps1
+++ b/src/tests/functions/Get-DscResourceParameterInfoByCimClass.Tests.ps1
@@ -1,0 +1,62 @@
+Describe 'Get-DscResourceParameterInfoByCimClass' {
+  InModuleScope puppet.dsc {
+    # TODO: When Pester 5 comes out we can skip on the context or describe blocks and supply a reason.
+    # For now, it just marks as passed but does not run except in an elevated context.
+    $RunningElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')
+    Context 'basic functionality' {
+      It 'returns parameter info for resources without embedded CIM instances' -Skip:(!$RunningElevated) {
+        # We cannot effectively mock out the underlying object, so we need to retrieve a
+        # well-known DSC resource at a specific version
+        $CimlessDscResource = Get-DscResource -Name Archive -Module @{
+          ModuleName    = 'PSDscResources'
+          ModuleVersion = '2.12.0.0'
+        }
+        $CimlessParameterToInspect = Get-DscResourceParameterInfoByCimClass -DscResource $CimlessDscResource |
+          Sort-Object -Property Name |
+          Select-Object -Last 1
+        $CimlessParameterToInspect.Name              | Should -BeExactly 'validate'
+        # This function currently cannot discover default values
+        $CimlessParameterToInspect.DefaultValue      | Should -BeNullOrEmpty
+        $CimlessParameterToInspect.Type              | Should -BeExactly '"Optional[Boolean]"'
+        $CimlessParameterToInspect.Help              | Should -MatchExactly '^Specifies whether or not'
+        $CimlessParameterToInspect.mandatory_for_get | Should -BeExactly 'false'
+        $CimlessParameterToInspect.mandatory_for_set | Should -BeExactly 'false'
+        $CimlessParameterToInspect.mof_is_embedded   | Should -BeExactly 'false'
+        # This surface is different from Get-DscResourceParameterInfo, but only used for embedded instances
+        # which this property is not.
+        # $CimlessParameterToInspect.mof_type | Should -BeExactly 'bool'
+        $CimlessParameterToInspect.mof_type          | Should -BeExactly 'Boolean'
+      }
+      It 'returns parameter info for resources with embedded CIM instances' -Skip:(!$RunningElevated) {
+        # We cannot effectively mock out the underlying object, so we need to retrieve a
+        # well-known DSC resource at a specific version
+        $CimfulDscResource = Get-DscResource -Name NTFSAccessEntry -Module @{
+          ModuleName    = 'AccessControlDSC'
+          ModuleVersion = '1.4.0.0'
+        }
+        $CimfulParameterToInspect = Get-DscResourceParameterInfoByCimClass -DscResource $CimfulDscResource |
+          Sort-Object -Property Name |
+          Select-Object -First 1
+        $CimfulParameterToInspect.Name              | Should -BeExactly 'accesscontrollist'
+        # This function currently cannot discover default values
+        $CimfulParameterToInspect.DefaultValue      | Should -BeNullOrEmpty
+        $CimfulParameterToInspect.Type              | Should -MatchExactly ([Regex]::Escape('"Array[Struct[{'))
+        $CimfulParameterToInspect.Help              | Should -MatchExactly '^Indicates the access control information'
+        $CimfulParameterToInspect.mandatory_for_get | Should -BeExactly 'true'
+        $CimfulParameterToInspect.mandatory_for_set | Should -BeExactly 'true'
+        $CimfulParameterToInspect.mof_is_embedded   | Should -BeExactly 'true'
+        $CimfulParameterToInspect.mof_type          | Should -BeExactly 'NTFSAccessControlList[]'
+      }
+    }
+    Context "When the resource can't be found" {
+      Mock Initialize-DscResourceCimClass {Throw 'foo'}
+      $DscResource = Get-DscResource -Name Archive -Module @{
+        ModuleName    = 'PSDscResources'
+        ModuleVersion = '2.12.0.0'
+      }
+      It 'stops processing' -Skip:(!$RunningElevated) {
+        { Get-DscResourceParameterInfoByCimClass -DscResource $DscResource } | Should -Throw
+      }
+    }
+  }
+}

--- a/src/tests/functions/Get-DscResourceTypeInformation.Tests.ps1
+++ b/src/tests/functions/Get-DscResourceTypeInformation.Tests.ps1
@@ -1,97 +1,212 @@
 Describe "Parameter Handling" {
   InModuleScope puppet.dsc {
-    Context "When Passed a DscResourceInfo object" {
-      Mock Get-DscResource {}
-      Mock Get-DscResourceParameterInfo { return $DscResource.Name }
-      $DscResources = [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo[]]@(
-        @{Name = 'foo'}
-        @{Name = 'bar'}
-      )
-      
-      $Result = $DscResources | Get-DscResourceTypeInformation
-      
-      It "processes once for each object in the pipeline" {
-        Assert-MockCalled Get-DscResourceParameterInfo -Times 2
-        $Result[0].ParameterInfo | Should -be $Result[0].Name
+    Context "When running elevated" {
+      Context "When Passed a DscResourceInfo object" {
+        Mock Get-DscResource {}
+        Mock Test-RunningElevated                   { return $true }
+        Mock Get-DscResourceParameterInfoByCimClass { return $DscResource.Name }
+        Mock Get-DscResourceParameterInfo           { return $DscResource.Name }
+        $DscResources = [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo[]]@(
+          @{Name = 'foo'}
+          @{Name = 'bar'}
+        )
+        
+        $Result = $DscResources | Get-DscResourceTypeInformation
+        
+        It "processes once for each object in the pipeline" {
+          Assert-MockCalled Get-DscResourceParameterInfoByCimClass -Times 2
+          $Result[0].ParameterInfo | Should -be $Result[0].Name
+        }
+
+        It "never calls Get-DscResource" {
+          Assert-MockCalled Get-DscResource -Times 0
+        }
       }
 
-      It "never calls Get-DscResource" {
-        Assert-MockCalled Get-DscResource -Times 0
-      }
-    }
+      Context "When specifying properties" {
+        Context "by name only" {
+          Mock Test-RunningElevated                   { return $true }
+          Mock Get-DscResourceParameterInfoByCimClass { return $DscResource.Name }
+          Mock Get-DscResourceParameterInfo           { return $DscResource.Name }
+          Mock Get-DscResource {
+            ForEach-Object -InputObject $Name -Process {
+              [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+                Name = $Name
+              }
+            }
+          }
 
-    Context "When specifying properties" {
-      Context "by name only" {
-        Mock Get-DscResourceParameterInfo { return $DscResource.Name }
-        Mock Get-DscResource {
-          ForEach-Object -InputObject $Name -Process {
+          It 'calls Get-DscResource once' {
+            $Result = Get-DscResourceTypeInformation -Name foo, bar, baz
+            $Result[0].ParameterInfo | Should -Be $Result[0].Name
+            Assert-MockCalled Get-DscResource -Times 1
+          }
+        }
+
+        Context "by name and module" {
+          Mock Test-RunningElevated                   { return $true }
+          Mock Get-DscResourceParameterInfoByCimClass { return $DscResource.Name }
+          Mock Get-DscResourceParameterInfo           { return $DscResource.Name }
+          Mock Get-DscResource {
             [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
               Name = $Name
             }
           }
+          Mock Get-DscResource {
+            [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+              Name = $Module
+            }
+          }  -ParameterFilter { $null -ne $Module }
+
+          $Result = Get-DscResourceTypeInformation -Name bar -Module foo
+
+          It 'Only searches by module if specified' {
+            $Result.ParameterInfo | Should -Be 'foo'
+            Assert-MockCalled Get-DscResource -Times 1
+            Assert-MockCalled Get-DscResource -Times 1 -ParameterFilter {
+              $Module -eq 'foo'
+            }
+          }
         }
 
-        It 'calls Get-DscResource once' {
-          $Result = Get-DscResourceTypeInformation -Name foo, bar, baz
-          $Result[0].ParameterInfo | Should -Be $Result[0].Name
-          Assert-MockCalled Get-DscResource -Times 1
+        Context 'via the pipeline' {
+          Mock Test-RunningElevated                   { return $true }
+          Mock Get-DscResourceParameterInfoByCimClass { return $DscResource.Name }
+          Mock Get-DscResourceParameterInfo           { return $DscResource.Name }
+          Mock Get-DscResource {
+            [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+              Name = $Name
+            }
+          }  -ParameterFilter { $Name -eq 'foo' }
+          Mock Get-DscResource {
+            [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+              Name = $Module
+            }
+          } -ParameterFilter { $Module -eq 'baz' }
+
+          # Objects with name and module properties to pass to the function
+          $NameOnly = [PSCustomObject]@{ Name = 'foo' }
+          $NameAndModule = [PSCustomObject]@{
+            Name = 'bar'
+            Module = 'baz'
+          }
+          $Results = $NameOnly,$NameAndModule | Get-DscResourceTypeInformation
+
+          It 'handles pipeline input by property name' {
+            $Results.Count | Should -Be 2
+            $Results[0].Name | Should -Be 'foo'
+            $Results[1].Name | Should -Be 'baz'
+          }
+
+          It 'processes once for each resource found' {
+            Assert-MockCalled Get-DscResource -Times 2
+            Assert-MockCalled Get-DscResourceParameterInfoByCimClass -Times 2
+          }
         }
       }
-
-      Context "by name and module" {
-        Mock Get-DscResourceParameterInfo { return $DscResource.Name }
-        Mock Get-DscResource {
-          [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
-            Name = $Name
-          }
-        }
-        Mock Get-DscResource {
-          [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
-            Name = $Module
-          }
-        }  -ParameterFilter { $null -ne $Module }
-
-        $Result = Get-DscResourceTypeInformation -Name bar -Module foo
-
-        It 'Only searches by module if specified' {
-          $Result.ParameterInfo | Should -Be 'foo'
-          Assert-MockCalled Get-DscResource -Times 1
-          Assert-MockCalled Get-DscResource -Times 1 -ParameterFilter {
-            $Module -eq 'foo'
-          }
-        }
-      }
-
-      Context 'via the pipeline' {
-        Mock Get-DscResourceParameterInfo { return $DscResource.Name }
-        Mock Get-DscResource {
-          [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
-            Name = $Name
-          }
-        }  -ParameterFilter { $Name -eq 'foo' }
-        Mock Get-DscResource {
-          [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
-            Name = $Module
-          }
-        } -ParameterFilter { $Module -eq 'baz' }
-
-        # Objects with name and module properties to pass to the function
-        $NameOnly = [PSCustomObject]@{ Name = 'foo' }
-        $NameAndModule = [PSCustomObject]@{
-          Name = 'bar'
-          Module = 'baz'
-        }
-        $Results = $NameOnly,$NameAndModule | Get-DscResourceTypeInformation
-
-        It 'handles pipeline input by property name' {
-          $Results.Count | Should -Be 2
-          $Results[0].Name | Should -Be 'foo'
-          $Results[1].Name | Should -Be 'baz'
-        }
-
-        It 'processes once for each resource found' {
-          Assert-MockCalled Get-DscResource -Times 2
+    }
+    Context "When running unelevated" {
+      Context "When Passed a DscResourceInfo object" {
+        Mock Get-DscResource {}
+        Mock Test-RunningElevated                   { return $false }
+        Mock Get-DscResourceParameterInfoByCimClass { return $DscResource.Name }
+        Mock Get-DscResourceParameterInfo           { return $DscResource.Name }
+        $DscResources = [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo[]]@(
+          @{Name = 'foo'}
+          @{Name = 'bar'}
+        )
+        
+        $Result = $DscResources | Get-DscResourceTypeInformation
+        
+        It "processes once for each object in the pipeline" {
           Assert-MockCalled Get-DscResourceParameterInfo -Times 2
+          $Result[0].ParameterInfo | Should -be $Result[0].Name
+        }
+
+        It "never calls Get-DscResource" {
+          Assert-MockCalled Get-DscResource -Times 0
+        }
+      }
+
+      Context "When specifying properties" {
+        Context "by name only" {
+          Mock Test-RunningElevated                   { return $false }
+          Mock Get-DscResourceParameterInfoByCimClass { return $DscResource.Name }
+          Mock Get-DscResourceParameterInfo           { return $DscResource.Name }
+          Mock Get-DscResource {
+            ForEach-Object -InputObject $Name -Process {
+              [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+                Name = $Name
+              }
+            }
+          }
+
+          It 'calls Get-DscResource once' {
+            $Result = Get-DscResourceTypeInformation -Name foo, bar, baz
+            $Result[0].ParameterInfo | Should -Be $Result[0].Name
+            Assert-MockCalled Get-DscResource -Times 1
+          }
+        }
+
+        Context "by name and module" {
+          Mock Test-RunningElevated                   { return $false }
+          Mock Get-DscResourceParameterInfoByCimClass { return $DscResource.Name }
+          Mock Get-DscResourceParameterInfo           { return $DscResource.Name }
+          Mock Get-DscResource {
+            [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+              Name = $Name
+            }
+          }
+          Mock Get-DscResource {
+            [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+              Name = $Module
+            }
+          }  -ParameterFilter { $null -ne $Module }
+
+          $Result = Get-DscResourceTypeInformation -Name bar -Module foo
+
+          It 'Only searches by module if specified' {
+            $Result.ParameterInfo | Should -Be 'foo'
+            Assert-MockCalled Get-DscResource -Times 1
+            Assert-MockCalled Get-DscResource -Times 1 -ParameterFilter {
+              $Module -eq 'foo'
+            }
+          }
+        }
+
+        Context 'via the pipeline' {
+          Mock Test-RunningElevated                   { return $false }
+          Mock Get-DscResourceParameterInfoByCimClass { return $DscResource.Name }
+          Mock Get-DscResourceParameterInfo           { return $DscResource.Name }
+          Mock Get-DscResource {
+            [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+              Name = $Name
+            }
+          }  -ParameterFilter { $Name -eq 'foo' }
+          Mock Get-DscResource {
+            [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+              Name = $Module
+            }
+          } -ParameterFilter { $Module -eq 'baz' }
+
+          # Objects with name and module properties to pass to the function
+          $NameOnly = [PSCustomObject]@{ Name = 'foo' }
+          $NameAndModule = [PSCustomObject]@{
+            Name = 'bar'
+            Module = 'baz'
+          }
+          $Results = $NameOnly,$NameAndModule | Get-DscResourceTypeInformation
+
+          It 'handles pipeline input by property name' {
+            $Results.Count | Should -Be 2
+            $Results[0].Name | Should -Be 'foo'
+            $Results[1].Name | Should -Be 'baz'
+          }
+
+          It 'processes once for each resource found' {
+            Assert-MockCalled Get-DscResource -Times 2
+            Assert-MockCalled Get-DscResourceParameterInfo -Times 2
+          }
         }
       }
     }

--- a/src/tests/functions/Get-EmbeddedCimInstance.Tests.ps1
+++ b/src/tests/functions/Get-EmbeddedCimInstance.Tests.ps1
@@ -1,0 +1,61 @@
+Describe 'Get-EmbeddedCimInstance' {
+  InModuleScope puppet.dsc {
+    Context 'basic functionality' {
+      Mock Get-CimClassPropertiesList {
+        @(
+          [pscustomobject]@{ Qualifiers = @([pscustomobject]@{ Name='foo';Value='bar' }) }
+          [pscustomobject]@{ Qualifiers = @([pscustomobject]@{ Name='EmbeddedInstance';Value='bar' }) }
+        )
+      } -ParameterFilter {$ClassName -eq 'foo'}
+      Mock Get-CimClassPropertiesList {
+        @(
+          [pscustomobject]@{ Qualifiers = @([pscustomobject]@{ Name='EmbeddedInstance';Value='baz' }) }
+        )
+      } -ParameterFilter {$ClassName -eq 'bar'}
+      Mock Get-CimClassPropertiesList {
+        @(
+          [pscustomobject]@{ Qualifiers = @([pscustomobject]@{ Name='baz';Value='bing' }) }
+        )
+      } -ParameterFilter {$ClassName -eq 'baz'}
+
+      $Result = Get-EmbeddedCimInstance -ClassName foo
+      It 'returns every discovered property for the CIM class' {
+        $Result.count | Should -Be 1
+        $Result       | Should -Be 'bar'
+      }
+      It 'Calls Get-CimClass once' {
+        Assert-MockCalled -CommandName Get-CimClassPropertiesList -Times 1
+      }
+      It 'looks in the DSC namespace by default' {
+        Assert-MockCalled -CommandName Get-CimClassPropertiesList -Times 1 -ParameterFilter {
+          $Namespace -eq 'root\Microsoft\Windows\DesiredStateConfiguration'
+        }
+      }
+    }
+    Context 'when run recursively' {
+      Mock Get-CimClassPropertiesList {
+        @(
+          [pscustomobject]@{ Qualifiers = @([pscustomobject]@{ Name='foo';Value='bar' }) }
+          [pscustomobject]@{ Qualifiers = @([pscustomobject]@{ Name='EmbeddedInstance';Value='bar' }) }
+        )
+      } -ParameterFilter {$ClassName -eq 'foo'}
+      Mock Get-CimClassPropertiesList {
+        @(
+          [pscustomobject]@{ Qualifiers = @([pscustomobject]@{ Name='EmbeddedInstance';Value='baz' }) }
+        )
+      } -ParameterFilter {$ClassName -eq 'bar'}
+      Mock Get-CimClassPropertiesList {
+        @(
+          [pscustomobject]@{ Qualifiers = @([pscustomobject]@{ Name='baz';Value='bing' }) }
+        )
+      } -ParameterFilter {$ClassName -eq 'baz'}
+
+      It 'returns every discovered property for the CIM class and nested CIM Classes' {
+        $RecursiveResult = Get-EmbeddedCimInstance -ClassName foo -Recurse
+        $RecursiveResult.count | Should -Be 2
+        $RecursiveResult[0]    | Should -Be 'bar'
+        $RecursiveResult[1]    | Should -Be 'baz'
+      }
+    }
+  }
+}

--- a/src/tests/functions/Initialize-DscResourceCimClass.Tests.ps1
+++ b/src/tests/functions/Initialize-DscResourceCimClass.Tests.ps1
@@ -1,0 +1,24 @@
+Describe 'Initialize-DscResourceCimClass' {
+  InModuleScope puppet.dsc {
+    Context 'basic functionality' {
+      Mock Invoke-DscResource {
+        Throw "invalid attempt"
+      } -ParameterFilter { $Name -eq 'foo' }
+      Mock Invoke-DscResource {
+        Throw "Resource $Name was not found"
+      } -ParameterFilter { $Name -ne 'foo' }
+
+      It 'does not throw an error if the specified resource is found' {
+        {Initialize-DscResourceCimClass -Name 'foo' -ModuleName 'baz' -ModuleVersion '1.2.3'} |
+          Should -Not -Throw
+      }
+      It 'Calls Invoke-DscResource once' {
+        Assert-MockCalled -CommandName Invoke-DscResource -Times 1
+      }
+      It 'throws an error if the specified resource cannot be found' {
+        {Initialize-DscResourceCimClass -Name 'bar' -ModuleName 'baz' -ModuleVersion '1.2.3'} |
+          Should -Throw
+      }
+    }
+  }
+}

--- a/src/tests/functions/Test-SymLinkedItem.Tests.ps1
+++ b/src/tests/functions/Test-SymLinkedItem.Tests.ps1
@@ -1,0 +1,25 @@
+Describe 'Test-SymLinkedItem' {
+  InModuleScope puppet.dsc {
+    Context 'Basic verification' {
+      Mock Get-Item {
+        return [PSCustomObject]@{ LinkType = 'SymLink' ; Path = $Path }
+      } -ParameterFilter { $Path -eq 'TestDrive:\foo\bar\baz\qux' }
+      Mock Get-Item {
+        return [PSCustomObject]@{ LinkType = $null ; Path = $Path }
+      } -ParameterFilter { $Path -eq 'TestDrive:\foo\bar\baz' }
+      Mock Get-Item {
+        return [PSCustomObject]@{ LinkType = 'SymLink' ; Path = $Path }
+      } -ParameterFilter { $Path -eq 'TestDrive:\foo\bar' }
+
+      It 'returns true if the specified path is a symlink' {
+        Test-SymLinkedItem -Path 'TestDrive:\foo\bar\baz\qux' | Should -BeTrue
+      }
+      It 'returns false if the specified path is not a symlink' {
+        Test-SymLinkedItem -Path 'TestDrive:\foo\bar\baz' | Should -BeFalse
+      }
+      It 'returns true if any part of the path is a symlink and -Recurse is specified' {
+        Test-SymLinkedItem -Path 'TestDrive:\foo\bar\baz' -Recurse | Should -BeTrue
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR plumbs the `Get-DscTypeInformation` function to be aware of whether or not it is running in an elevated context or not and to retrieve the parameter information by CIM class if it *is* running elevated, or by AST/Resource metadata if not.

It does so by implementing the `Get-DscResourceParameterInfoByCimClass` function, an alternate implementation of `Get-DscResourceParameterInfo`, which could not parse embedded CIM instances. The new function can, but will only work if run as administrator. 

In practice, this means our type attribute definitions for DSC resources with CIM instance properties go from this:

```puppet
dsc_accesscontrollist: {
      type: "Array[Hash]",
      desc: %q{
        Indicates the access control information in the form of an array of instances of the NTFSAccessControlList CIM class.
      },
      behaviour: :namevar,
      mandatory_for_get: true,
      mandatory_for_set: true,
      mof_type: 'NTFSAccessControlList[]',
      mof_is_embedded: true,
    },
```

to this:

```puppet
dsc_accesscontrollist: {
      type: "Array[Struct[{
              accesscontrolentry => Array[Struct[{
                accesscontroltype => Enum['allow', 'deny'],
                inheritance => Enum['this folder only', 'this folder subfolders and files', 'this folder and subfolders', 'this folder and files', 'subfolders and files only', 'subfolders only', 'files only'],
                ensure => Enum['present', 'absent'],
                cim_instance_type => 'ntfsaccesscontrolentry',
                filesystemrights => Array[Enum['appenddata', 'changepermissions', 'createdirectories', 'createfiles', 'delete', 'deletesubdirectoriesandfiles', 'executefile', 'fullcontrol', 'listdirectory', 'modify', 'read', 'readandexecute', 'readattributes', 'readdata', 'readextendedattributes', 'readpermissions', 'synchronize', 'takeownership', 'traverse', 'write', 'writeattributes', 'writedata', 'writeextendedattributes']]
              }]],
              forceprincipal => Optional[Boolean],
              principal => Optional[String],
            }]]",
      desc: %q{
        Indicates the access control information in the form of an array of instances of the NTFSAccessControlList CIM class.
      },
      behaviour: :namevar,
      mandatory_for_get: true,
      mandatory_for_set: true,
      mof_type: 'NTFSAccessControlList[]',
      mof_is_embedded: true,
    },
```

Note that where before the end-user had to figure out all the correct keys and data types themself, and know to put `cim_instance_type` for nested CIM instances, the new iteration automatically maps CIM instances to structs (including nested instances) and will provide authoring aid (if using the VSCode extension)  and compile time checking instead of raising a confusing error during an apply run.