### PR TITLE
Ensure that metadata field `summary` is always less than 144 length

### DIFF
--- a/src/internal/functions/Update-PuppetModuleMetadata.ps1
+++ b/src/internal/functions/Update-PuppetModuleMetadata.ps1
@@ -43,7 +43,12 @@ function Update-PuppetModuleMetadata {
       $PuppetMetadata.author = $PuppetModuleAuthor
     }
     $PuppetMetadata.version = Get-PuppetModuleVersion -Version $PowerShellMetadata.ModuleVersion
-    $PuppetMetadata.summary = $PowerShellMetadata.Description -Replace "(`r`n|`n)", '`n'
+    $summary = $PowerShellMetadata.Description -Replace "(`r`n|`n)", '`n'
+    # summary needs to be 144 chars or less (see https://github.com/voxpupuli/metadata-json-lint/blob/5ab67f9404ee65da0efd84a597b2ee86152d2659/lib/metadata-json-lint/schema.rb#L99 )
+    if ($summary.length -gt 144) {
+      $summary = $summary.substring(0, 144 - 3) + "..."
+    }
+    $PuppetMetadata.summary = $summary
     $PuppetMetadata.source  = $PowerShellMetadata.PrivateData.PSData.ProjectUri
     # If we can find the issues page, link to it, otherwise default to project page.
     Switch -Regex ($PowerShellMetadata.PrivateData.PSData.ProjectUri) {

--- a/src/tests/functions/Update-PuppetModuleMetadata.Tests.ps1
+++ b/src/tests/functions/Update-PuppetModuleMetadata.Tests.ps1
@@ -58,7 +58,10 @@ Describe 'Update-PuppetModuleMetadata' {
           $Result.version | Should -Be '2.2.3-0-0'
         }
         It 'Updates the summary' {
-          $Result.summary | Should -Be 'PowerShell module with commands for discovering, installing, updating and publishing the PowerShell artifacts like Modules, DSC Resources, Role Capabilities and Scripts.'
+          $Result.summary | Should -Be 'PowerShell module with commands for discovering, installing, updating and publishing the PowerShell artifacts like Modules, DSC Resources, Ro...'
+        }
+        It 'Has the summary shorter or equal to 144 chars' {
+          $Result.summary.length | Should -LE 144
         }
         It 'Updates the source' {
           $Result.source | Should -Be 'https://go.microsoft.com/fwlink/?LinkId=828955'


### PR DESCRIPTION
The metadata-json-lint tool requires at most 144 characters in the `summary` field. This change truncates the summary accordingly.

See https://github.com/voxpupuli/metadata-json-lint/blob/5ab67f9404ee65da0efd84a597b2ee86152d2659/lib/metadata-json-lint/schema.rb#L99