### PR TITLE
(IAC-861) Update CI scripts to fail AppVeyor runs on test failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,9 @@ test_script:
       $ErrorActionPreference = "Stop"
       & .\src\tests\pester.ps1
 
-      $res = Invoke-Pester -PassThru .\build.Tests.ps1
+      $testResultsFile = ".\AcceptanceTestsResults.xml"
+      $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru .\build.Tests.ps1
+      (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
       if ($res.FailedCount -gt 0) {
         throw "$($res.FailedCount) tests failed."
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ install:
   - ps: |
       $ErrorActionPreference = "Stop"
       & .\extras\install.ps1
+      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
+
 build: off
 environment:
   PDK_DISABLE_ANALYTICS: 'true'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,10 @@ test_script:
       $ErrorActionPreference = "Stop"
       & .\src\tests\pester.ps1
 
-      Invoke-Pester .\build.Tests.ps1
+      $res = Invoke-Pester -PassThru .\build.Tests.ps1
+      if ($res.FailedCount -gt 0) {
+        throw "$($res.FailedCount) tests failed."
+      }
 notifications:
   - provider: Email
     on_build_success: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,17 @@
 version: 1.0.x.{build}
 clone_depth: 10
 install:
-  - ps: '& .\extras\install.ps1'
+  - ps: |
+      $ErrorActionPreference = "Stop"
+      & .\extras\install.ps1
 build: off
 environment:
   PDK_DISABLE_ANALYTICS: 'true'
 test_script:
-  - ps: '& .\src\tests\pester.ps1'
-  - ps: 'Invoke-Pester .\build.Tests.ps1'
+  - ps: |
+      $ErrorActionPreference = "Stop"
+      & .\src\tests\pester.ps1
+      Invoke-Pester .\build.Tests.ps1
 notifications:
   - provider: Email
     on_build_success: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ test_script:
   - ps: |
       $ErrorActionPreference = "Stop"
       & .\src\tests\pester.ps1
+
       Invoke-Pester .\build.Tests.ps1
 notifications:
   - provider: Email

--- a/build.Tests.ps1
+++ b/build.Tests.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 # . "$here\$sut"
@@ -10,7 +12,7 @@ $expected_base = '../bar/powershellget'
 
 Remove-Item $expected_base -Force -Recurse -ErrorAction Ignore
 
-& $script -ErrorAction Stop -PowerShellModuleName "PowerShellGet" -PowerShellModuleVersion "2.1.3"  -OutputDirectory "../bar"
+& $script -PowerShellModuleName "PowerShellGet" -PowerShellModuleVersion "2.1.3"  -OutputDirectory "../bar"
 
 # remove test instances left over from a previous run
 try {

--- a/extras/install.ps1
+++ b/extras/install.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 $ChocolateyPackages = @(
   'pester'
   'pdk'
@@ -12,7 +14,13 @@ if ($ENV:CI -ne 'True') {
   )
 }
 
-choco install $ChocolateyPackages -y --no-progress
+Write-Host "Installing with choco: $ChocolateyPackages"
+
+choco install $ChocolateyPackages --yes --no-progress --stop-on-first-failure
+if ($LastExitCode -ne 0) {
+  throw "Installation with choco failed."
+}
+
 $PowerShellModules = @(
   @{ Name = 'PSFramework' }
   @{ Name = 'PSModuleDevelopment' }
@@ -24,6 +32,7 @@ $PowerShellModules = @(
   @{ Name = 'PSDscResources' ; RequiredVersion = '2.12.0.0' }
   @{ Name = 'AccessControlDsc' ; RequiredVersion = '1.4.0.0' }
 )
+Write-Host "Installing $($PowerShellModules.Count) modules with Install-Module"
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 ForEach ($Module in $PowerShellModules) {
   Install-Module @Module -Force

--- a/src/tests/pester.ps1
+++ b/src/tests/pester.ps1
@@ -11,6 +11,8 @@ param (
   $Exclude = ""
 )
 
+$ErrorActionPreference = "Stop"
+
 Write-PSFMessage -Level Important -Message "Starting Tests"
 
 Write-PSFMessage -Level Important -Message "Importing Module"
@@ -27,7 +29,7 @@ if ($TestGeneral)
   foreach ($file in (Get-ChildItem "$PSScriptRoot\general" | Where-Object Name -like "*.Tests.ps1"))
   {
     Write-PSFMessage -Level Significant -Message "  Executing <c='em'>$($file.Name)</c>"
-    Invoke-Pester -Script $file.FullName -Show $Show
+    $results = Invoke-Pester -Script $file.FullName -Show $Show -PassThru
     foreach ($result in $results)
     {
       $totalFailed += $result.FailedCount

--- a/src/tests/pester.ps1
+++ b/src/tests/pester.ps1
@@ -25,11 +25,15 @@ $totalFailed = 0
 #region Run General Tests
 if ($TestGeneral)
 {
+  $testResultsFile = ".\GeneralTestsResults.xml"
   Write-PSFMessage -Level Important -Message "Modules imported, proceeding with general tests"
   foreach ($file in (Get-ChildItem "$PSScriptRoot\general" | Where-Object Name -like "*.Tests.ps1"))
   {
     Write-PSFMessage -Level Significant -Message "  Executing <c='em'>$($file.Name)</c>"
-    $results = Invoke-Pester -Script $file.FullName -Show $Show -PassThru
+    $results = Invoke-Pester -Script $file.FullName -Show $Show -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
+    if ($env:APPVEYOR -eq 'True') {
+      (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
+    }
     foreach ($result in $results)
     {
       $totalFailed += $result.FailedCount
@@ -48,7 +52,10 @@ if ($TestFunctions)
     if ($file.Name -like $Exclude) { continue }
 
     Write-PSFMessage -Level Significant -Message "  Executing <c='em'>$($file.Name)</c>"
-    $results = Invoke-Pester -Script $file.FullName -Show $Show -PassThru
+    $results = Invoke-Pester -Script $file.FullName -Show $Show -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
+    if ($env:APPVEYOR -eq 'True') {
+      (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
+    }
     foreach ($result in $results)
     {
       $totalFailed += $result.FailedCount


### PR DESCRIPTION
Follow [AppVeyor's recommendations for handling error conditions in powershell](https://www.appveyor.com/docs/build-configuration/#interpreters-and-scripts).