### PR TITLE
(IAC-846) Canonicalize Puppet module author names

### DIFF
--- a/src/functions/New-PuppetDscModule.ps1
+++ b/src/functions/New-PuppetDscModule.ps1
@@ -48,6 +48,8 @@ Function New-PuppetDscModule {
   Begin {
     # Unless specified, use a valid Puppet module name
     If ([string]::IsNullOrEmpty($PuppetModuleName)) { $PuppetModuleName = Get-PuppetizedModuleName -Name $PowerShellModuleName }
+    # If specified, canonicalize the Puppet module author name
+    If (![string]::IsNullOrEmpty($PuppetModuleAuthor)) { $PuppetModuleAuthor = ConvertTo-CanonicalPuppetAuthorName -AuthorName $PuppetModuleAuthor }
     # Default to the `import` folder in the current path
     If ([string]::IsNullOrEmpty($OutputDirectory))  {
       $OutputDirectory  = Join-Path -Path (Get-Location) -ChildPath 'import'

--- a/src/internal/functions/ConvertTo-CanonicalPuppetAuthorName.ps1
+++ b/src/internal/functions/ConvertTo-CanonicalPuppetAuthorName.ps1
@@ -1,0 +1,31 @@
+Function ConvertTo-CanonicalPuppetAuthorName {
+  <#
+    .SYNOPSIS
+      Convert a string to a valid Puppet module author name
+    .DESCRIPTION
+      Convert a string to a valid Puppet module author name, replacing any non-alphanumeric
+      characters with underscores, downcasing the strin, and trimming any extraneous underscores.
+    .PARAMETER AuthorName
+      The string to convert into a canonicalized Puppet module author name.
+    .EXAMPLE
+      "foo bar" | ConvertTo-CanonicalPuppetAuthorName
+      
+      This command will return the string 'foo_bar', which is a valid Puppet module author name.
+  #>
+  [cmdletbinding()]
+  param(
+    [Parameter(ValueFromPipeline)]
+    [string]$AuthorName
+  )
+
+  Begin {}
+
+  Process {
+    # Puppet module author names must be lower cased alphanumeric
+    $CanonicalAuthorName = $AuthorName.ToLower() -replace '[^a-zA-Z\d]+', '_'
+    # An author name likely should neither end nor begin with one or more underscores
+    $CanonicalAuthorName.trim('_')
+  }
+
+  End {}
+}

--- a/src/tests/functions/ConvertTo-CanonicalPuppetAuthorName.ps1
+++ b/src/tests/functions/ConvertTo-CanonicalPuppetAuthorName.ps1
@@ -1,0 +1,18 @@
+Describe 'ConvertTo-CanonicalPuppetAuthorName' {
+  InModuleScope puppet.dsc {
+    Context 'Basic verification' {
+      It 'lower-cases author name' {
+        ConvertTo-CanonicalPuppetAuthorName -AuthorName 'FoObAr' | Should -MatchExactly 'foobar'
+      }
+      It 'replaces invalid characters' {
+        ConvertTo-CanonicalPuppetAuthorName -AuthorName 'foo bar&@_*baz' | Should -MatchExactly 'foo_bar_baz'
+      }
+      It 'trims underscores' {
+        ConvertTo-CanonicalPuppetAuthorName -AuthorName '@#foo*(' | Should -MatchExactly 'foo'
+      }
+      It 'takes input from the pipeline' {
+        'Foo Bar' | ConvertTo-CanonicalPuppetAuthorName | Should -MatchExactly 'foo_bar'
+      }
+    }
+  }
+}


### PR DESCRIPTION
Prior to this commit it was possible for a user to specify a
Puppet module author name as a string which was not a valid
name - that is, included non-alphanumeric characters and/or
uppercase characters.

This commit adds a private function for canonicalizing the
author name and ensures that the author name is canonicalized
when called for creating a new module.