### PR TITLE
(IAC-804) Implement PSDscRunAsCredential

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
 test_script:
   - ps: |
       $ErrorActionPreference = "Stop"
+
       & .\src\tests\pester.ps1
 
       $testResultsFile = ".\AcceptanceTestsResults.xml"


### PR DESCRIPTION
Prior to this commit specifying a PSDscRunAsCredential to run a DSC resource as was not possible, the run errored unpredictably.

This commit updates the base provider to handle running as another user, including handling logon errors and failures and caching them to prevent recurring failures.

Two limitations in this implementation exist:

1. It is not currently possible to cease processing a resource if there is an error with the credentials (e.g. unauthorized or bad password) so code paths have been introduced to handle this and minimize additional calls to the system.
2. Something in the way that Puppet compares Sensitive values is causing the strict check for canonicalization of retrieved data to fail, resulting in a warning message that claims the values are different while displaying identical (to the screen) results for the retrieved and canonicalized values.

However, the resources do not flap when the credentials are correct and have sufficient permissions to perform the action. Canonicalization continues to function as expected.