### PR TITLE
(MAINT) Update pwshlib reference to 0.5.0

### DIFF
--- a/src/internal/functions/Update-PuppetModuleMetadata.ps1
+++ b/src/internal/functions/Update-PuppetModuleMetadata.ps1
@@ -73,7 +73,7 @@ function Update-PuppetModuleMetadata {
     $PuppetMetadata.dependencies = @(
       @{
         name = 'puppetlabs/pwshlib'
-        version_requirement = '>= 0.4.0 < 2.0.0'
+        version_requirement = '>= 0.5.0 < 2.0.0'
       }
     )
     # Update the operating sytem to only support windows *for now*.

--- a/src/tests/functions/Update-PuppetModuleMetadata.Tests.ps1
+++ b/src/tests/functions/Update-PuppetModuleMetadata.Tests.ps1
@@ -74,7 +74,7 @@ Describe 'Update-PuppetModuleMetadata' {
         }
         It 'Updates the dependencies' {
           $Result.dependencies[0].Name | Should -Be 'puppetlabs/pwshlib'
-          $Result.dependencies[0].version_requirement | Should -Be '>= 0.4.0 < 2.0.0'
+          $Result.dependencies[0].version_requirement | Should -Be '>= 0.5.0 < 2.0.0'
         }
         It 'Updates the supported operating system list' {
           $Result.operatingsystem_support[0].operatingsystem | Should -Be 'windows'


### PR DESCRIPTION
Prior to this commit the metadata in a puppetized module erroneously
specified requiring pwshlib 0.4.0 or higher; this is insufficient,
because 0.5.0 is the release that implements and includes the base
DSC provider that these puppetized modules rely on.